### PR TITLE
WIP: Calibration of topo cluster, adding options to rebase pileup and use segmented HCal cells

### DIFF
--- a/config/overlayPileup.py
+++ b/config/overlayPileup.py
@@ -141,19 +141,24 @@ overlay.doShuffleInputFiles = True
 overlay.randomizePileup = True
 overlay.mergeTools = [
     "PileupCaloHitMergeTool/ECalBarrelHitMerge",
-    "PileupCaloHitMergeTool/ECalEndcapHitMerge",
-    "PileupCaloHitMergeTool/ECalFwdHitMerge",
     "PileupCaloHitMergeTool/HCalBarrelHitMerge",
-    "PileupCaloHitMergeTool/HCalExtBarrelHitMerge",
-    "PileupCaloHitMergeTool/HCalEndcapHitMerge",
-    "PileupCaloHitMergeTool/HCalFwdHitMerge"]
+    ]
+
+if not rebase:
+    overlay.mergeTools += [
+        "PileupCaloHitMergeTool/ECalEndcapHitMerge",
+        "PileupCaloHitMergeTool/ECalFwdHitMerge",
+        "PileupCaloHitMergeTool/HCalExtBarrelHitMerge",
+        "PileupCaloHitMergeTool/HCalEndcapHitMerge",
+        "PileupCaloHitMergeTool/HCalFwdHitMerge"
+        ]
     
 overlay.PileUpTool = pileuptool
 overlay.noSignal = noSignal
 
 ecalBarrelOutput1 = "mergedECalBarrelCells"
 hcalBarrelOutput1 = "mergedHCalBarrelCells"
-
+hcalBarrelOutput2 = ""
 if rebase:
     # name of output of pileup merge
     ecalBarrelOutput1 = "mergedECalBarrelCellsStep1"
@@ -266,19 +271,23 @@ rebaseHcalBarrelCells = CreateCaloCells("RebaseHCalBarrelCells",
 # PODIO algorithm
 from Configurables import PodioOutput
 out = PodioOutput("out")
-out.outputCommands = ["drop *", "keep mergedGenVertices", "keep mergedGenParticles", "keep mergedECalBarrelCells", "keep mergedECalEndcapCells", "keep mergedECalFwdCells", "keep mergedHCalBarrelCells", "keep mergedHCalExtBarrelCells", "keep mergedHCalEndcapCells", "keep mergedHCalFwdCells"]
+out.outputCommands = ["drop *", "keep GenVertices", "keep GenParticles", "keep mergedECalBarrelCells", "keep mergedECalEndcapCells", "keep mergedECalFwdCells", "keep mergedHCalBarrelCells", "keep mergedHCalExtBarrelCells", "keep mergedHCalEndcapCells", "keep mergedHCalFwdCells"]
 out.filename = output_name
 
 list_of_algorithms += [overlay,
                        createEcalBarrelCells,
-                       createEcalEndcapCells,
-                       createEcalFwdCells,
                        createHcalBarrelCells,
-                       createHcalExtBarrelCells,
-                       createHcalEndcapCells,
-                       createHcalFwdCells,
                        ]
-
+if not rebase:
+    list_of_algorithms += [
+        createEcalEndcapCells,
+        createEcalFwdCells,
+        createHcalBarrelCells,
+        createHcalExtBarrelCells,
+        createHcalEndcapCells,
+        createHcalFwdCells,
+        ]
+    
 if rebase:
     if resegmentHCal:
         list_of_algorithms += [

--- a/config/overlayPileup.py
+++ b/config/overlayPileup.py
@@ -7,6 +7,8 @@ simparser.add_argument('-N','--numEvents', type=int, help='Number of simulation 
 simparser.add_argument('--pileup', type=int, help='Pileup', default = 1000)
 simparser.add_argument('--rebase', action='store_true', help='Rebase the merged PU to baseline 0, with averaged mean values.', default=False)
 simparser.add_argument('--prefixCollections', type=str, help='Prefix added to the collection names', default="")
+simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/afs/cern.ch/work/c/cneubuse/public/TopoClusters/FCCSW/")
+simparser.add_argument("--resegmentHCal", action='store_true', help="Merge HCal cells in DeltaEta=0.025 bins", default = False)
 simargs, _ = simparser.parse_known_args()
 
 print "=================================="
@@ -18,6 +20,8 @@ input_name = simargs.inName
 pileup = simargs.pileup
 prefix = simargs.prefixCollections
 noSignal = True
+path_to_detector = simargs.detectorPath
+resegmentHCal = simargs.resegmentHCal
 if simargs.inSignalName:
     signalFilename = simargs.inSignalName
     print "input signal name: ", signalFilename
@@ -48,11 +52,19 @@ if simargs.inSignalName:
     
     list_of_algorithms = [podioinput]
     pileup = 1
+
 else:
     noSignal = True
     list_of_algorithms = []
     from Configurables import FCCDataSvc
     podioevent = FCCDataSvc("EventDataSvc")
+
+
+detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml']
+
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use, OutputLevel = WARNING)
 
 import random
 seed=int(filter(str.isdigit, output_name))
@@ -143,8 +155,13 @@ ecalBarrelOutput1 = "mergedECalBarrelCells"
 hcalBarrelOutput1 = "mergedHCalBarrelCells"
 
 if rebase:
+    # name of output of pileup merge
     ecalBarrelOutput1 = "mergedECalBarrelCellsStep1"
     hcalBarrelOutput1 = "mergedHCalBarrelCellsStep1"
+    # input for rebase
+    hcalBarrelOutput2 = hcalBarrelOutput1
+    if resegmentHCal:
+        hcalBarrelOutput2 = "newHCalBarrelCells"
 
 ##############################################################################################################
 #######                                       DIGITISATION                                       #############
@@ -187,11 +204,45 @@ createHcalFwdCells = CreateCaloCells("CreateHcalFwdCells",
 createHcalFwdCells.hits.Path="pileupHCalFwdCells"
 createHcalFwdCells.cells.Path="mergedHCalFwdCells"
 
+########
+# RESEGMENT HCAL CELLS
+########
+from Configurables import CreateVolumeCaloPositions,RedoSegmentation,CreateCaloCells
+# Create cells in HCal
+# 2. step - rewrite the cellId using the Phi-Eta segmentation
+# 3. step - merge new cells corresponding to eta-phi segmentation
+# Hcal barrel cell positions
+posHcalBarrel = CreateVolumeCaloPositions("posBarrelHcal", OutputLevel = INFO)
+posHcalBarrel.hits.Path = hcalBarrelOutput1
+posHcalBarrel.positionedHits.Path = "HCalBarrelPositions"
+
+# Use Phi-Eta segmentation in Hcal barrel
+resegmentHcalBarrel = RedoSegmentation("ReSegmentationHcal",
+                                       # old bitfield (readout)
+                                       oldReadoutName = "HCalBarrelReadout",
+                                       # specify which fields are going to be altered (deleted/rewritten)
+                                       oldSegmentationIds = ["module","row"],
+                                       # new bitfield (readout), with new segmentation
+                                       newReadoutName = "BarHCal_Readout_phieta",
+                                       inhits = "HCalBarrelPositions",
+                                       outhits = "HCalBarrelCellsStep2")
+
+createSegHcalBarrelCells = CreateCaloCells("CreateSegHCalBarrelCells",
+                                           doCellCalibration=False, recalibrateBaseline =False,
+                                           addCellNoise=False, filterCellNoise=False,
+                                           hits="HCalBarrelCellsStep2",
+                                           cells="newHCalBarrelCells")
+
 ##############################################################################################################
 #######                                       REBASE PU TO 0                              #############
 ##############################################################################################################
+# Need to resegment HCal cells
+# pileup noise levels always in DeltaEta=0.025 cells
+
 #Configure tools for calo cell positions
-inputPileupNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_fullGranularity_electronicsNoiseLevel_forPU"+str(simargs.pileup)+".root"
+inputPileupNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_electronicsNoiseLevel_forPU"+str(simargs.pileup)+".root"
+if resegmentHCal:
+    inputPileupNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/resegmentedHCal/cellNoise_map_electronicsNoiseLevel_forPU"+str(simargs.pileup)+".root"
 
 from Configurables import TopoCaloNoisyCells
 readNoisyCellsMap = TopoCaloNoisyCells("ReadNoisyCellsMap",
@@ -210,7 +261,7 @@ rebaseHcalBarrelCells = CreateCaloCells("RebaseHCalBarrelCells",
                                         addCellNoise=False, filterCellNoise=False,
                                         recalibrateBaseline =True,
                                         readCellNoiseTool = readNoisyCellsMap,
-                                        hits=hcalBarrelOutput1,
+                                        hits=hcalBarrelOutput2,
                                         cells="mergedHCalBarrelCells")
 # PODIO algorithm
 from Configurables import PodioOutput
@@ -228,11 +279,15 @@ list_of_algorithms += [overlay,
                        createHcalFwdCells,
                        ]
 
-if rebase: 
+if rebase:
+    if resegmentHCal:
+        list_of_algorithms += [
+            posHcalBarrel,
+            resegmentHcalBarrel, 
+            createSegHcalBarrelCells, ]
     list_of_algorithms += [
         rebaseEcalBarrelCells,
-        rebaseHcalBarrelCells,
-        ]
+        rebaseHcalBarrelCells, ]
     
 list_of_algorithms += [out]
 
@@ -241,6 +296,6 @@ from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg=list_of_algorithms,
                 EvtSel='NONE',
                 EvtMax=num_events,
-                ExtSvc=[podioevent],
+                ExtSvc=[geoservice,podioevent],
 #                OutputLevel = DEBUG
                 )

--- a/config/preparePileup.py
+++ b/config/preparePileup.py
@@ -63,7 +63,7 @@ HCalBcellVols = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalBarrelVols",
                                                  OutputLevel = INFO)
 HCalBsegcells = CellPositionsHCalBarrelTool("CellPositionsHCalSegBarrel",
                                             readoutName = hcalBarrelReadoutNamePhiEta,
-                                            radii = [291.05, 301.05, 313.55, 328.55, 343.55, 358.55, 378.55, 413.55, 428.55, 453.55],
+                                            radii = [2910.5, 3010.5, 3135.5, 3285.5, 3435.5, 3585.5, 3785.5, 4135.5, 4285.5, 4535.5],
                                             OutputLevel = INFO)
 
 ##############################################################################################################                                                                                           #######                                       RESEGMENT HCAL                                   #############                                                                                             ##############################################################################################################                                                                                                                              

--- a/config/preparePileup.py
+++ b/config/preparePileup.py
@@ -108,7 +108,7 @@ ecalBarrelGeometry = TubeLayerPhiEtaCaloTool("EcalBarrelGeo",
                                              fieldNames = ["system"],
                                              fieldValues = [5],
                                              activeVolumesNumber = 8)
-# Geometry for layer-eta-phi segmentation                                                                                                                                                                
+# Geometry for layer-eta-phi segmentation                                                                                           
 hcalBarrelGeometry = LayerPhiEtaCaloTool("hcalBarrelGeometry",
                                          readoutName = "BarHCal_Readout_phieta",
                                          activeVolumeName = "layerVolume",
@@ -119,7 +119,7 @@ hcalBarrelGeometry = LayerPhiEtaCaloTool("hcalBarrelGeometry",
                                          activeVolumesEta = [1.2524, 1.2234, 1.1956, 1.15609, 1.1189, 1.08397, 1.0509, 0.9999, 0.9534, 0.91072]
                                          )
 
-# No segmentation, geometry with nested volumes                                                                                                                                                          
+# No segmentation, geometry with nested volumes                                                                                                        
 hcalgeo = NestedVolumesCaloTool("hcalgeo",
                                 activeVolumeName = hcalVolumeName,
                                 activeFieldName = hcalIdentifierName,
@@ -151,6 +151,14 @@ towers.hcalExtBarrelCells.Path = "emptyCaloCells"
 towers.hcalEndcapCells.Path = "emptyCaloCells"
 towers.hcalFwdCells.Path = "emptyCaloCells"
 
+inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_segHcal_electronicsNoiseLevel.root"
+if resegmentHCal:
+    inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_electronicsNoiseLevel.root"
+
+# use topo-cluster map of electronics noise level per Barrel cell
+from Configurables import TopoCaloNoisyCells
+readNoisyCellsMap = TopoCaloNoisyCells("ReadNoisyCellsMap",
+                                       fileName = inputNoisePerCell)
 # call pileup tool
 # prepare TH2 histogram with pileup per abs(eta)
 from Configurables import PreparePileup
@@ -160,6 +168,7 @@ pileupEcalBarrel = PreparePileup("PreparePileupEcalBarrel",
                                  layerFieldName = "layer",
                                  towerTool = towers,
                                  positionsTool = ECalBcells,
+                                 noiseTool = readNoisyCellsMap,
                                  histogramName = "ecalBarrelEnergyVsAbsEta",
                                  numLayers = 8,
                                  etaSize = [7,  5,  7,   9,   3,   3,  99],
@@ -173,13 +182,14 @@ if resegmentHCal:
     hcalGeoService = hcalBarrelGeometry
     hcalCellPositions = HCalBsegcells
     hcalReadoutName = hcalBarrelReadoutNamePhiEta
-
+    
 pileupHcalBarrel = PreparePileup("PreparePileupHcalBarrel",
                                  geometryTool = hcalGeoService,
                                  readoutName = hcalReadoutName,
                                  positionsTool = hcalCellPositions,
                                  layerFieldName = "layer",
                                  towerTool = towers,
+                                 noiseTool = readNoisyCellsMap,
                                  histogramName = "hcalBarrelEnergyVsAbsEta",
                                  numLayers = 10,
                                  etaSize = [7,  5,  7,   9,   3,   3,  99],

--- a/config/preparePileup.py
+++ b/config/preparePileup.py
@@ -4,6 +4,7 @@ simparser.add_argument('--inName', type=str, help='Name of the input file', requ
 simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
 simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj")
 simparser.add_argument('--prefixCollections', type=str, help='Prefix added to the collection names', default="")
+simparser.add_argument("--resegmentHCal", action='store_true', help="Merge HCal cells in DeltaEta=0.025 bins", default = False)
 simargs, _ = simparser.parse_known_args()
 
 print "=================================="
@@ -12,11 +13,13 @@ print "=================================="
 input_name = simargs.inName
 output_name = simargs.outName
 path_to_detector = simargs.detectorPath
+resegmentHCal = simargs.resegmentHCal
 print "detectors are taken from: ", path_to_detector
 print "input name: ", input_name
 print "output name: ", output_name
 prefix = simargs.prefixCollections
 print "prefix : ", prefix
+print "resegment HCal: ", resegmentHCal
 print "=================================="
 
 from Gaudi.Configuration import *
@@ -42,11 +45,15 @@ geoservice = GeoSvc("GeoSvc", detectors = [ path_to_detector+'/Detector/DetFCChh
 ecalBarrelReadoutNamePhiEta = "ECalBarrelPhiEta"
 hcalBarrelReadoutName = "HCalBarrelReadout"
 hcalBarrelReadoutNamePhiEta = "BarHCal_Readout_phieta"
+# active material identifier name
+hcalIdentifierName = ["module", "row", "layer"]
+# active material volume name
+hcalVolumeName = ["moduleVolume", "wedgeVolume", "layerVolume"]
+# ECAL bitfield names & values 
+hcalFieldNames=["system"]
+hcalFieldValues=[8]
 
-##############################################################################################################                                                                                                 
-#######                                       CELL POSITIONS  TOOLS                              #############                                                                                                 
-##############################################################################################################                                                                                                                              
-# Configure tools for calo cell positions                                                                            
+##############################################################################################################                                                                                           #######                                       CELL POSITIONS  TOOLS                              #############                                                                                           ##############################################################################################################                                                                                           # Configure tools for calo cell positions                                                                            
 from Configurables import CellPositionsECalBarrelTool, CellPositionsHCalBarrelNoSegTool, CellPositionsHCalBarrelTool
 ECalBcells = CellPositionsECalBarrelTool("CellPositionsECalBarrel",
                                          readoutName = ecalBarrelReadoutNamePhiEta,
@@ -59,14 +66,12 @@ HCalBsegcells = CellPositionsHCalBarrelTool("CellPositionsHCalSegBarrel",
                                             radii = [291.05, 301.05, 313.55, 328.55, 343.55, 358.55, 378.55, 413.55, 428.55, 453.55],
                                             OutputLevel = INFO)
 
-##############################################################################################################                                                                                                          
-#######                                       RESEGMENT HCAL                                   #############                                                                                                                                
-##############################################################################################################                                                                                                                              
+##############################################################################################################                                                                                           #######                                       RESEGMENT HCAL                                   #############                                                                                             ##############################################################################################################                                                                                                                              
 from Configurables import CreateVolumeCaloPositions,RedoSegmentation,CreateCaloCells,CreateCellPositions
 # Create cells in HCal                                           
 # 2. step - rewrite the cellId using the Phi-Eta segmentation    
 # 3. step - merge new cells corresponding to eta-phi segmentation
-# Hcal barrel cell positions                                                                                                                                                                                                                 
+# Hcal barrel cell positions                                                                                                                                                                             
 posHcalBarrel = CreateCellPositions("posHcalBarrel",
                                     positionsTool=HCalBcellVols,
                                     hits = prefix+"HCalBarrelCells",
@@ -76,21 +81,26 @@ posHcalBarrel = CreateCellPositions("posHcalBarrel",
 resegmentHcalBarrel = RedoSegmentation("ReSegmentationHcal",
                                        # old bitfield (readout) 
                                        oldReadoutName = hcalBarrelReadoutName,
-                                       # specify which fields are going to be altered (deleted/rewritten)                                                                                                                              
+                                       # specify which fields are going to be altered (deleted/rewritten)
                                        oldSegmentationIds = ["module","row"],
-                                       # new bitfield (readout), with new segmentation                                                                                                                                                 
+                                       # new bitfield (readout), with new segmentation                                                                                     
                                        newReadoutName = hcalBarrelReadoutNamePhiEta,
                                        inhits = "HCalBarrelPositions",
                                        outhits = "HCalBarrelCellsStep2")
-
+    
 createHcalBarrelCells = CreateCaloCells("CreateHCalBarrelCells",
                                         doCellCalibration=False,recalibrateBaseline =False, 
                                         addCellNoise=False, filterCellNoise=False,
                                         hits="HCalBarrelCellsStep2",
                                         cells="newHCalBarrelCells")
+hcalCells = prefix+"HCalBarrelCells"
+hcalCellsForTowers = "HCalBarrelCellsStep2"
+if resegmentHCal:
+    hcalCells = "newHCalBarrelCells"
+    hcalCellsForTowers = "newHCalBarrelCells"
 
 # geometry tool
-from Configurables import TubeLayerPhiEtaCaloTool, LayerPhiEtaCaloTool
+from Configurables import TubeLayerPhiEtaCaloTool, LayerPhiEtaCaloTool, NestedVolumesCaloTool
 ecalBarrelGeometry = TubeLayerPhiEtaCaloTool("EcalBarrelGeo",
                                              readoutName = ecalBarrelReadoutNamePhiEta,
                                              activeVolumeName = "LAr_sensitive",
@@ -98,8 +108,8 @@ ecalBarrelGeometry = TubeLayerPhiEtaCaloTool("EcalBarrelGeo",
                                              fieldNames = ["system"],
                                              fieldValues = [5],
                                              activeVolumesNumber = 8)
-# Geometry for layer-eta-phi segmentation                                                                                                                                                                                                  
-hcalBarrelGeometry = LayerPhiEtaCaloTool("HcalBarrelGeo",
+# Geometry for layer-eta-phi segmentation                                                                                                                                                                
+hcalBarrelGeometry = LayerPhiEtaCaloTool("hcalBarrelGeometry",
                                          readoutName = "BarHCal_Readout_phieta",
                                          activeVolumeName = "layerVolume",
                                          activeFieldName = "layer",
@@ -108,6 +118,14 @@ hcalBarrelGeometry = LayerPhiEtaCaloTool("HcalBarrelGeo",
                                          activeVolumesNumber = 10,
                                          activeVolumesEta = [1.2524, 1.2234, 1.1956, 1.15609, 1.1189, 1.08397, 1.0509, 0.9999, 0.9534, 0.91072]
                                          )
+
+# No segmentation, geometry with nested volumes                                                                                                                                                          
+hcalgeo = NestedVolumesCaloTool("hcalgeo",
+                                activeVolumeName = hcalVolumeName,
+                                activeFieldName = hcalIdentifierName,
+                                readoutName = "HCalBarrelReadout",
+                                fieldNames = hcalFieldNames,
+                                fieldValues = hcalFieldValues)
 
 from Configurables import CreateEmptyCaloCellsCollection
 createemptycells = CreateEmptyCaloCellsCollection("CreateEmptyCaloCells")
@@ -128,7 +146,7 @@ towers = CaloTowerTool("towers",
 towers.ecalBarrelCells.Path = prefix+"ECalBarrelCells"
 towers.ecalEndcapCells.Path = "emptyCaloCells"
 towers.ecalFwdCells.Path = "emptyCaloCells"
-towers.hcalBarrelCells.Path = "newHCalBarrelCells"
+towers.hcalBarrelCells.Path = hcalCellsForTowers
 towers.hcalExtBarrelCells.Path = "emptyCaloCells"
 towers.hcalEndcapCells.Path = "emptyCaloCells"
 towers.hcalFwdCells.Path = "emptyCaloCells"
@@ -141,22 +159,32 @@ pileupEcalBarrel = PreparePileup("PreparePileupEcalBarrel",
                                  readoutName = ecalBarrelReadoutNamePhiEta,
                                  layerFieldName = "layer",
                                  towerTool = towers,
+                                 positionsTool = ECalBcells,
                                  histogramName = "ecalBarrelEnergyVsAbsEta",
                                  numLayers = 8,
                                  etaSize = [7,  5,  7,   9,   3,   3,  99],
                                  phiSize = [19, 15, 21, 21,  15,  11, 101])
 pileupEcalBarrel.hits.Path=prefix+"ECalBarrelCells"
 
+hcalGeoService = hcalgeo
+hcalCellPositions = HCalBcellVols
+hcalReadoutName = hcalBarrelReadoutName
+if resegmentHCal:
+    hcalGeoService = hcalBarrelGeometry
+    hcalCellPositions = HCalBsegcells
+    hcalReadoutName = hcalBarrelReadoutNamePhiEta
+
 pileupHcalBarrel = PreparePileup("PreparePileupHcalBarrel",
-                                 geometryTool = hcalBarrelGeometry,
-                                 readoutName = hcalBarrelReadoutNamePhiEta,
+                                 geometryTool = hcalGeoService,
+                                 readoutName = hcalReadoutName,
+                                 positionsTool = hcalCellPositions,
                                  layerFieldName = "layer",
                                  towerTool = towers,
                                  histogramName = "hcalBarrelEnergyVsAbsEta",
                                  numLayers = 10,
                                  etaSize = [7,  5,  7,   9,   3,   3,  99],
                                  phiSize = [19, 15, 21, 21,  15,  11, 101])
-pileupHcalBarrel.hits.Path="newHCalBarrelCells"
+pileupHcalBarrel.hits.Path=hcalCells
 
 THistSvc().Output = ["rec DATAFILE='" + output_name + "' TYP='ROOT' OPT='RECREATE'"]
 THistSvc().PrintAll=True
@@ -171,16 +199,21 @@ audsvc = AuditorSvc()
 audsvc.Auditors = [chra]
 podioinput.AuditExecute = True
 
+list_of_algorithms = [ podioinput,
+                       createemptycells,
+                       posHcalBarrel,
+                       resegmentHcalBarrel, ]
+
+if resegmentHCal:
+    list_of_algorithms += [ createHcalBarrelCells, ]
+    
+list_of_algorithms += [ pileupEcalBarrel,
+                        pileupHcalBarrel ]
+
 ApplicationMgr(
-    TopAlg = [podioinput,
-              posHcalBarrel,
-              resegmentHcalBarrel,
-              createHcalBarrelCells,
-              createemptycells,
-              pileupEcalBarrel,
-              pileupHcalBarrel,
-              ],
+    TopAlg = list_of_algorithms,
     EvtSel = 'NONE',
     EvtMax = -1,
     ExtSvc = [podioevent, geoservice],
+#    OutputLevel = DEBUG
  )

--- a/config/recPositions.py
+++ b/config/recPositions.py
@@ -338,7 +338,6 @@ if noise:
 ##############################################################################################################
 if simargs.cone:
     print 'Cell collections for cone selection: ', ecalBarrelCellsForSelection, hcalBarrelCellsForSelection
-    print 'HCal Cell posiitons tool for cone selection: ', hcalCellPositionsTool
     # Select cells before running clustering
     from Configurables import ConeSelection
     selectionECalBarrel = ConeSelection("selectionECalBarrel",

--- a/config/recPositions.py
+++ b/config/recPositions.py
@@ -181,7 +181,7 @@ createHcalExtBarrelCells = CreateCaloCells("CreateHCalExtBarrelCells",
                                            hits="HCalExtBarrelCellsStep2",
                                            cells="newHCalExtBarrelCells")
 if resegmentHCal:
-    hcalBarrelCellsForPositions = "newHCalExtBarrelCells"
+    hcalBarrelCellsForPositions = "newHCalBarrelCells"
 
 ##############################################################################################################                                                                            
 #######                                       GEOMETRIES                                     #############                                                                             
@@ -439,6 +439,8 @@ if addMuons:
     list_of_algorithms += [positionsTailCatcher]
 
 list_of_algorithms += [out]
+
+print list_of_algorithms
 
 ApplicationMgr(
     TopAlg = list_of_algorithms,

--- a/config/recPositions.py
+++ b/config/recPositions.py
@@ -8,6 +8,7 @@ simparser.add_argument('--prefixCollections', type=str, help='Prefix added to th
 simparser.add_argument("--addMuons", action='store_true', help="Add tail catcher cells", default = False)
 simparser.add_argument("--resegmentHCal", action='store_true', help="Merge HCal cells in DeltaEta=0.025 bins", default = False)
 simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj")
+simparser.add_argument("--addElectronicsNoise", action='store_true', help="Add electronics noise (default: false)")
 
 simargs, _ = simparser.parse_known_args()
 
@@ -21,6 +22,7 @@ prefix = simargs.prefixCollections
 addMuons = simargs.addMuons
 resegmentHCal = simargs.resegmentHCal
 path_to_detector = simargs.detectorPath
+noise = simargs.addElectronicsNoise
 print "number of events = ", num_events
 print "input name: ", input_name
 print "output name: ", output_name
@@ -33,16 +35,14 @@ from Gaudi.Configuration import *
 #######                                         GEOMETRY                                         #############
 ##############################################################################################################
 detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
-                  path_to_detector+'/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
                   path_to_detector+'/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
-                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml',
-                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml',
-                  path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
-                  path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
-                  path_to_detector+'/Detector/DetFCChhTailCatcher/compact/FCChh_TailCatcher.xml',
-                  path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Solenoids.xml',
-                  path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Shielding.xml']
-
+                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml']
+if not noise:
+    detectors_to_use+=[path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml',
+                       path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
+                       path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
+                       path_to_detector+'/Detector/DetFCChhTailCatcher/compact/FCChh_TailCatcher.xml']
+    
 from Configurables import GeoSvc
 geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use, OutputLevel = WARNING)
 
@@ -59,6 +59,23 @@ hcalEndcapReadoutName = "HECPhiEtaReco"
 hcalFwdReadoutName = "HFwdPhiEta"
 # Tail Catcher readout
 tailCatcherReadoutName = "Muons_Readout"
+
+# cell collections used for positions reco
+ecalBarrelCellsForPositions = prefix+"ECalBarrelCells"
+hcalBarrelCellsForPositions = prefix+"HCalBarrelCells"
+
+# Geometry details to add noise to every Calo cell and paths to root files that have the noise const per cell
+ecalBarrelNoisePath = "/afs/cern.ch/user/a/azaborow/public/FCCSW/elecNoise_ecalBarrel_50Ohm_traces2_2shieldWidth_noise.root"
+ecalBarrelNoiseHistName = "h_elecNoise_fcc_"
+hcalBarrelNoiseHistName = "h_elec_hcal_layer"
+# active material identifier name
+hcalIdentifierName = ["module", "row", "layer"]
+# active material volume name
+hcalVolumeName = ["moduleVolume", "wedgeVolume", "layerVolume"]
+# ECAL bitfield names & values
+hcalFieldNames=["system"]
+hcalFieldValues=[8]
+
 ##############################################################################################################
 #######                                        INPUT                                             #############
 ##############################################################################################################
@@ -66,7 +83,9 @@ tailCatcherReadoutName = "Muons_Readout"
 from Configurables import ApplicationMgr, FCCDataSvc, PodioInput, PodioOutput
 podioevent = FCCDataSvc("EventDataSvc", input=input_name)
 
-coll_names_read = [prefix+"ECalBarrelCells", prefix+"HCalBarrelCells", prefix+"HCalExtBarrelCells", prefix+"ECalEndcapCells", prefix+"HCalEndcapCells", prefix+"ECalFwdCells", prefix+"HCalFwdCells"]
+coll_names_read = [prefix+"ECalBarrelCells", prefix+"HCalBarrelCells"]
+if not noise:
+    coll_names_read += [prefix+"HCalExtBarrelCells", prefix+"ECalEndcapCells", prefix+"HCalEndcapCells", prefix+"ECalFwdCells", prefix+"HCalFwdCells"]
 if not prefix:
     coll_names_read += ["GenParticles", "GenVertices"]
 if addMuons:
@@ -74,6 +93,7 @@ if addMuons:
 
 podioinput = PodioInput("PodioReader", collections = coll_names_read, OutputLevel = DEBUG)
 
+ecalCells = prefix+"ECalBarrelCells"
 hcalCells = prefix+"HCalBarrelCells"
 hcalExtCells = prefix+"HCalExtBarrelCells"
 
@@ -116,12 +136,12 @@ from Configurables import CreateVolumeCaloPositions,RedoSegmentation,CreateCaloC
 # Create cells in HCal
 # 2. step - rewrite the cellId using the Phi-Eta segmentation
 # 3. step - merge new cells corresponding to eta-phi segmentation
-
-# Hcal barrel cell positions                                                                                                                                                                                                              
+# Hcal barrel cell positions
+                   
 posHcalBarrel = CreateVolumeCaloPositions("posBarrelHcal", OutputLevel = INFO)
 posHcalBarrel.hits.Path = hcalCells
 posHcalBarrel.positionedHits.Path = "HCalBarrelPositions"
-# Use Phi-Eta segmentation in Hcal barrel                                                                                                                                                                                                  
+# Use Phi-Eta segmentation in Hcal barrel       
 resegmentHcalBarrel = RedoSegmentation("ReSegmentationHcal",
                                        # old bitfield (readout)                         
                                        oldReadoutName = hcalBarrelReadoutName,
@@ -139,11 +159,11 @@ createHcalBarrelCells = CreateCaloCells("CreateHCalBarrelCells",
                                         hits="HCalBarrelCellsStep2",
                                         cells="newHCalBarrelCells")
 
-# Ext Hcal barrel cell positions                                                                                                                                                                                    
+# Ext Hcal barrel cell positions
 posHcalExtBarrel = CreateVolumeCaloPositions("posExtBarrelHcal", OutputLevel = INFO)
 posHcalExtBarrel.hits.Path = hcalExtCells
 posHcalExtBarrel.positionedHits.Path = "HCalExtBarrelPositions"
-# Use Phi-Eta segmentation in Hcal barrel                                                                                                                                                                                                  
+# Use Phi-Eta segmentation in Hcal barrel       
 resegmentHcalExtBarrel = RedoSegmentation("ReSegmentationHcalExt",
                                           # old bitfield (readout)   
                                           oldReadoutName = hcalExtBarrelReadoutName,
@@ -160,6 +180,40 @@ createHcalExtBarrelCells = CreateCaloCells("CreateHCalExtBarrelCells",
                                            OutputLevel=INFO,
                                            hits="HCalExtBarrelCellsStep2",
                                            cells="newHCalExtBarrelCells")
+if resegmentHCal:
+    hcalBarrelCellsForPositions = "newHCalExtBarrelCells"
+
+##############################################################################################################                                                                            
+#######                                       GEOMETRIES                                     #############                                                                             
+##############################################################################################################                                                                            
+from Configurables import NestedVolumesCaloTool, TubeLayerPhiEtaCaloTool, LayerPhiEtaCaloTool
+# add noise, create all existing cells in detector
+barrelEcalGeometry = TubeLayerPhiEtaCaloTool("BarrelEcalGeo",
+                                             readoutName = "ECalBarrelPhiEta",
+                                             activeVolumeName = "LAr_sensitive",
+                                             activeFieldName = "layer",
+                                             fieldNames = ["system"],
+                                             fieldValues = [5],
+                                             activeVolumesNumber = 8)
+
+# No segmentation, geometry with nested volumes
+hcalgeo = NestedVolumesCaloTool("HcalGeo",
+                                activeVolumeName = hcalVolumeName,
+                                activeFieldName = hcalIdentifierName,
+                                readoutName = "HCalBarrelReadout",
+                                fieldNames = hcalFieldNames,
+                                fieldValues = hcalFieldValues)
+
+# Geometry for layer-eta-phi segmentation
+barrelHcalGeometry = LayerPhiEtaCaloTool("BarrelHcalGeo",
+                                         readoutName = "BarHCal_Readout_phieta",
+                                         activeVolumeName = "layerVolume",
+                                         activeFieldName = "layer",
+                                         fieldNames = ["system"],
+                                         fieldValues = [8],
+                                         activeVolumesNumber = 10,
+                                         activeVolumesEta = [1.2524, 1.2234, 1.1956, 1.15609, 1.1189, 1.08397, 1.0509, 0.9999, 0.9534, 0.91072]
+                                         )
 
 ##############################################################################################################
 #######                                       CELL POSITIONS                                     #############
@@ -184,7 +238,7 @@ HCalExtBcells = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalExtBarrel",
                                                  OutputLevel = INFO)
 HCalBsegcells = CellPositionsHCalBarrelTool("CellPositionsHCalSegBarrel",
                                             readoutName = hcalBarrelReadoutNamePhiEta,
-                                            radii = [291.05, 301.05, 313.55, 328.55, 343.55, 358.55, 378.55, 403.55, 428.55, 453.55],
+                                            radii = [2910.5, 3010.5, 3135.5, 3285.5, 3435.5, 3585.5, 3785.5, 4035.5, 4285.5, 4535.5],
                                             OutputLevel = INFO)
 HCalExtBsegcells = CellPositionsHCalBarrelTool("CellPositionsHCalExtSegBarrel",
                                                readoutName = hcalExtBarrelReadoutNamePhiEta,
@@ -215,16 +269,64 @@ if addMuons:
                                                     centralRadius = 901.5,
                                                     OutputLevel = INFO)
 
+##############################################################################################################
+#######                                       NOISE                                     #############
+##############################################################################################################
+
+if noise:
+    ecalBarrelCellsForPositions = "ECalBarrelCellsNoise"
+    hcalBarrelCellsForPositions = "HCalBarrelCellsNoise"
+
+    from Configurables import CreateCaloCells, NoiseCaloCellsFromFileTool, CalibrateCaloHitsTool, NoiseCaloCellsFlatTool
+    # ECal Barrel noise
+    noiseEcalBarrel = NoiseCaloCellsFromFileTool("NoiseECalBarrel",
+                                                 readoutName = ecalBarrelReadoutName,
+                                                 noiseFileName = ecalBarrelNoisePath,
+                                                 elecNoiseHistoName = ecalBarrelNoiseHistName,
+                                                 cellPositionsTool = ECalBcells,
+                                                 activeFieldName = "layer",
+                                                 addPileup = False,
+                                                 numRadialLayers = 8)
+    
+    createEcalBarrelCellsNoise = CreateCaloCells("CreateECalBarrelCellsNoise",
+                                                 geometryTool = barrelEcalGeometry,
+                                                 doCellCalibration=False, recalibrateBaseline =False, # already calibrated                                                                  
+                                                 addCellNoise=True, filterCellNoise=False,
+                                                 noiseTool = noiseEcalBarrel,
+                                                 hits = ecalCells,
+                                                 cells = "ECalBarrelCellsNoise")
+    
+    # HCal Barrel noise                                                                                                                                                              
+    noiseHcal = NoiseCaloCellsFlatTool("HCalNoise", cellNoise = 0.01)
+    
+    if resegmentHCal:
+        createHcalBarrelCellsNoise = CreateCaloCells("CreateHCalBarrelCellsNoise",
+                                                     geometryTool = barrelHcalGeometry,
+                                                     doCellCalibration = False, recalibrateBaseline =False,
+                                                     addCellNoise = True, filterCellNoise = False,
+                                                     noiseTool = noiseHcal)
+        createHcalBarrelCellsNoise.hits.Path = "newHCalBarrelCells"
+        createHcalBarrelCellsNoise.cells.Path = "HCalBarrelCellsNoise"
+    else:
+        createHcalBarrelCellsNoise = CreateCaloCells("CreateHCalBarrelCellsNoise",
+                                                     geometryTool = hcalgeo,
+                                                     doCellCalibration = False, recalibrateBaseline =False,
+                                                     addCellNoise = True, filterCellNoise = False,
+                                                     noiseTool = noiseHcal)
+        createHcalBarrelCellsNoise.hits.Path = hcalCells
+        createHcalBarrelCellsNoise.cells.Path = "HCalBarrelCellsNoise"
+
+
 # cell positions
 from Configurables import CreateCellPositions
 positionsEcalBarrel = CreateCellPositions("positionsEcalBarrel",
                                           positionsTool=ECalBcells,
-                                          hits = prefix+"ECalBarrelCells",
+                                          hits = ecalBarrelCellsForPositions,
                                           positionedHits = "ECalBarrelCellPositions",
                                           OutputLevel = INFO)
 positionsHcalBarrel = CreateCellPositions("positionsHcalBarrel",
                                           positionsTool=HCalBcells,
-                                          hits = prefix+"HCalBarrelCells",
+                                          hits = hcalBarrelCellsForPositions,
                                           positionedHits = "HCalBarrelCellPositions",
                                           OutputLevel = INFO)
 positionsHcalExtBarrel = CreateCellPositions("positionsHcalExtBarrel",
@@ -239,7 +341,7 @@ positionsHcalSegBarrel = CreateCellPositions("positionsSegHcalBarrel",
                                           OutputLevel = INFO)
 positionsHcalSegExtBarrel = CreateCellPositions("positionsSegHcalExtBarrel",
                                           positionsTool=HCalExtBsegcells,
-                                          hits = "newHCalExtBarrelCells",
+                                          hits = hcalBarrelCellsForPositions,
                                           positionedHits = "HCalExtBarrelCellPositions",
                                           OutputLevel = INFO)
 positionsEcalEndcap = CreateCellPositions("positionsEcalEndcap",
@@ -295,15 +397,7 @@ out.AuditExecute = True
 
 list_of_algorithms = [podioinput]
 
-list_of_algorithms += [rewriteECalEC,
-                       rewriteHCalEC,
-                       positionsEcalBarrel,
-                       positionsEcalEndcap,
-                       positionsEcalFwd,
-                       positionsHcalEndcap,
-                       positionsHcalFwd,
-                       ]
-if resegmentHCal:
+if resegmentHCal and not noise:
     list_of_algorithms += [
         posHcalBarrel,
         posHcalExtBarrel,
@@ -311,14 +405,35 @@ if resegmentHCal:
         resegmentHcalExtBarrel,
         createHcalBarrelCells,
         createHcalExtBarrelCells,
-        positionsHcalSegBarrel,
-        positionsHcalSegExtBarrel
         ]
-else:
-    list_of_algorithms += [ positionsHcalBarrel,
-                            positionsHcalExtBarrel,
-                            ]
-        
+elif resegmentHCal and noise:
+    list_of_algorithms += [
+        posHcalBarrel,
+        resegmentHcalBarrel,
+        createHcalBarrelCells,
+        ]
+if noise and resegmentHCal:
+    list_of_algorithms += [
+        createEcalBarrelCellsNoise,
+        createHcalBarrelCellsNoise,
+        positionsEcalBarrel,
+        positionsHcalSegBarrel,
+        ]
+elif noise and not resegmentHCal:
+    list_of_algorithms += [ 
+        createEcalBarrelCellsNoise,
+        createHcalBarrelCellsNoise,
+        positionsEcalBarrel,
+        positionsHcalBarrel,
+        ]
+elif not noise:
+    list_of_algorithms += [rewriteECalEC,
+                           rewriteHCalEC,
+                           positionsEcalEndcap,
+                           positionsEcalFwd,
+                           positionsHcalEndcap,
+                           positionsHcalFwd,
+                           ]
 if addMuons:
     list_of_algorithms += [positionsTailCatcher]
 

--- a/config/recPositions.py
+++ b/config/recPositions.py
@@ -336,7 +336,7 @@ positionsHcalExtBarrel = CreateCellPositions("positionsHcalExtBarrel",
                                           OutputLevel = INFO)
 positionsHcalSegBarrel = CreateCellPositions("positionsSegHcalBarrel",
                                           positionsTool=HCalBsegcells,
-                                          hits = "newHCalBarrelCells",
+                                          hits = hcalBarrelCellsForPositions,
                                           positionedHits = "HCalBarrelCellPositions",
                                           OutputLevel = INFO)
 positionsHcalSegExtBarrel = CreateCellPositions("positionsSegHcalExtBarrel",
@@ -376,7 +376,7 @@ out = PodioOutput("out", OutputLevel=DEBUG)
 out.outputCommands = ["keep *","drop "+prefix+"ECalBarrelCells","drop "+prefix+"ECalEndcapCells","drop "+prefix+"ECalFwdCells","drop "+prefix+"HCalBarrelCells", "drop "+prefix+"HCalExtBarrelCells", "drop "+prefix+"HCalEndcapCells", "drop "+prefix+"HCalFwdCells"]
 if addMuons:
     out.outputCommands += ["drop TailCatcherCells"]
-out.filename = "edm.root"
+out.filename = output_name
 
 #CPU information
 from Configurables import AuditorSvc, ChronoAuditor
@@ -405,15 +405,14 @@ if resegmentHCal and not noise:
         resegmentHcalExtBarrel,
         createHcalBarrelCells,
         createHcalExtBarrelCells,
+        positionsEcalBarrel,
+        positionsHcalSegBarrel,
         ]
 elif resegmentHCal and noise:
     list_of_algorithms += [
         posHcalBarrel,
         resegmentHcalBarrel,
         createHcalBarrelCells,
-        ]
-if noise and resegmentHCal:
-    list_of_algorithms += [
         createEcalBarrelCellsNoise,
         createHcalBarrelCellsNoise,
         positionsEcalBarrel,
@@ -426,9 +425,11 @@ elif noise and not resegmentHCal:
         positionsEcalBarrel,
         positionsHcalBarrel,
         ]
-elif not noise:
+else:
     list_of_algorithms += [rewriteECalEC,
                            rewriteHCalEC,
+                           positionsEcalBarrel,
+                           positionsHcalBarrel,
                            positionsEcalEndcap,
                            positionsEcalFwd,
                            positionsHcalEndcap,

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -11,6 +11,7 @@ simparser.add_argument('--sigma2', type=float, default=2., help='Energy threshol
 simparser.add_argument('--sigma3', type=int, default=0, help='Energy threshold [in number of sigmas] for last neighbours')
 simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj")
 simparser.add_argument("--calibrate", action='store_true', help="Calibrate clusters (default: false)")
+simparser.add_argument("--benchmark", action='store_true', help="Calibrate clusters, using cell-level benchmark parameters (default: false)")
 simparser.add_argument("--pileup", type=int, help="Added pileup events to signal", default=0)
 simparser.add_argument('--prefixCollections', type=str, help='Prefix added to the collection names', default="")
 simparser.add_argument("--resegmentHCal", action='store_true', help="Merge HCal cells in DeltaEta=0.025 bins", default = False)
@@ -64,6 +65,7 @@ benchmark_c = -7.4E-6
 benchmark_d = 0. #-.92
 benchmark_e = 1. #0.9697
 benchmark_f = 1. #1./0.9956
+
 if bFieldOff:
     emSampl_hcal = 0.0249
     benchmark_a = 1.062
@@ -72,7 +74,11 @@ if bFieldOff:
     benchmark_d = 0. #-.83
     benchmark_e = 1. #0.9834
     benchmark_f = 1. #1./0.9973
+
 # from minimisation (bFieldOn, C=0): 0.975799,-2.54738e-06,0.822663,-0.140975,-2.18657e-05,-0.0193682
+edepCalib = True
+benchCalib = False
+
 a1 = 0.975799
 a2 = -2.54738e-06
 a3 = 0.822663
@@ -82,6 +88,21 @@ b3 = -0.0193682
 c1 = 0
 c2 = 0
 c3 = 1
+if simargs.benchmark:
+    calib = True
+    edepCalib = False
+    benchCalib = True
+    a1 = benchmark_a
+    a2 = 0.
+    a3 = 0.
+    b1 = benchmark_b
+    b2 = 0.
+    b3 = 0.
+    c1 = benchmark_c
+    c2 = 0.
+    c3 = 0.
+    
+
 # no distrinction of shared clusters needed
 fractionECal = 1
 
@@ -482,7 +503,8 @@ if elNoise and not puNoise:
                                                     positionsHCalNoSegTool = HCalBcellVols,
                                                     noSegmentationHCal = noSegmentationHCal,
                                                     calibrate = True,
-                                                    eDepCryoCorrection = True,
+                                                    cryoCorrection = benchCalib,
+                                                    eDepCryoCorrection = edepCalib,
                                                     ehECal = 1.,
                                                     ehHCal = 1.,
                                                     a1 = a1,
@@ -495,14 +517,6 @@ if elNoise and not puNoise:
                                                     c2 = c2,
                                                     c3 = c3,
                                                     fractionECal = fractionECal)
-# to be tested:
-#                                                    a = benchmark_a,
-#                                                    b = benchmark_b,
-#                                                    c = benchmark_c,
-#                                                    d = benchmark_d,
-#                                                    e = benchmark_e,
-#                                                    f = benchmark_f,
-#                                                    fractionECal = fractionECal)
 
         THistSvc().Output = ["rec DATAFILE='calibrateCluster_histograms.root' TYP='ROOT' OPT='RECREATE'"]
         THistSvc().PrintAll=True

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -263,7 +263,8 @@ if resegmentHCal:
     inputPileupNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_electronicsNoiseLevel_PU"+str(puEvents)+".root"
     if bFieldOff:
         inputPileupNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_electronicsNoiseLevel_PU"+str(puEvents)+".root"
-    inputTopoCellCollectionHCalBarrel = "newHCalBarrelCells"
+    if not addedPU > 0:
+        inputTopoCellCollectionHCalBarrel = "newHCalBarrelCells"
     hcalBarrelReadoutName = hcalBarrelReadoutNamePhiEta
     noSegmentationHCal = False
     inputPileupNoisePerCell.replace('mu', 'PU')
@@ -709,7 +710,7 @@ out.AuditExecute = True
 list_of_algorithms = [podioinput,
                       createemptycells]
 
-if resegmentHCal:
+if resegmentHCal and addedPU==0:
     list_of_algorithms += [posHcalBarrel, resegmentHcalBarrel, createHcalBarrelCells]
 
 if elNoise or puNoise:

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -173,8 +173,7 @@ hcalFieldValues=[8]
 inputCellCollectionECalBarrel = prefix+"ECalBarrelCells"
 inputCellCollectionHCalBarrel = prefix+"HCalBarrelCells"
 inputCollections = [prefix+"ECalBarrelCells", prefix+"HCalBarrelCells", ]
-if calib or simargs.cone:
-    inputCollections += ["GenParticles", "GenVertices"] 
+inputCollections += ["GenParticles", "GenVertices"] 
 inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_segHcal_constNoiseLevel.root"
 inputPileupNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_segHcal_noiseLevelElectronicsPileup_mu"+str(puEvents)+".root"
 inputNeighboursMap = "/afs/cern.ch/work/c/cneubuse/public/FCChh/neighbours_map_segHcal.root"

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -50,12 +50,22 @@ print "no B field: ", bFieldOff
 # correct EM calibration of hcal cells                                                                                                                                                    
 hadronSampl_hcal = 0.024
 emSampl_hcal = 0.0255
+# Paramerters for cluster calibration                                                                                                                                         
+# Bfield on:
+benchmark_a = 0.996
+benchmark_b = 0.565
+benchmark_c = -7.4E-6
+benchmark_d = 0. #-.92
+benchmark_e = 1. #0.9697
+benchmark_f = 1. #1./0.9956
 if bFieldOff:
     emSampl_hcal = 0.0249
-# Paramerters for cluster calibration                                                                                                                                         
-benchmark_a = 1.07
-benchmark_b = 0.76
-benchmark_c = -1.9E-5
+    benchmark_a = 1.062
+    benchmark_b = 0.659
+    benchmark_c = -6.3E-6
+    benchmark_d = 0. #-.83
+    benchmark_e = 1. #0.9834
+    benchmark_f = 1. #1./0.9973
 # from minimisation (bFieldOn, C=0): 0.975799,-2.54738e-06,0.822663,-0.140975,-2.18657e-05,-0.0193682
 a1 = 0.975799
 a2 = -2.54738e-06
@@ -436,18 +446,16 @@ if elNoise and not puNoise:
                                                     positionsHCalNoSegTool = HCalBcellVols,
                                                     noSegmentationHCal = noSegmentationHCal,
                                                     calibrate = True, # will not re-calibrate the ECal, but HCal cells are scaled to EM
-                                                    eDepCryoCorrection = True,
+                                                    cryoCorrection = True,
+                                                    eDepCryoCorrection = False,
                                                     ehECal = 1.,
-                                                    ehHCal = 1.1,
-                                                    a1 = a1,
-                                                    a2 = a2,
-                                                    a3 = a3,
-                                                    b1 = b1,
-                                                    b2 = b2,
-                                                    b3 = b3,
-                                                    c1 = c1,
-                                                    c2 = c2,
-                                                    c3 = c3,
+                                                    ehHCal = 1.,
+                                                    a = benchmark_a,
+                                                    b = benchmark_b,
+                                                    c = benchmark_c,
+                                                    d = benchmark_d,
+                                                    e = benchmark_e,
+                                                    f = benchmark_f,
                                                     fractionECal = fractionECal)
 
         THistSvc().Output = ["rec DATAFILE='calibrateCluster_histograms.root' TYP='ROOT' OPT='RECREATE'"]
@@ -741,7 +749,8 @@ list_of_algorithms += [out]
 ApplicationMgr(
     TopAlg = list_of_algorithms,
     EvtSel = 'NONE',
-    EvtMax   = num_events,
+    # test if set first ev 
+    EvtMax = num_events,
     ExtSvc = [geoservice, podioevent],
-#    OutputLevel = DEBUG
+    #    OutputLevel = DEBUG
 )

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -130,13 +130,7 @@ hcalFieldValues=[8]
 # inputs for topo-clustering
 inputCellCollectionECalBarrel = prefix+"ECalBarrelCells"
 inputCellCollectionHCalBarrel = prefix+"HCalBarrelCells"
-inputCollections = [inputCellCollectionECalBarrel,  inputCellCollectionHCalBarrel]
-
-if not prefix=="merged": 
-#and not prefix=="addedPU":
-    inputCollections += ["GenParticles", "GenVertices"]
-
-print "Reading collections: ", inputCollections
+inputCollections = [prefix+"ECalBarrelCells", prefix+"HCalBarrelCells", "GenParticles", "GenVertices"]
 
 inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_segHcal_constNoiseLevel.root"
 inputPileupNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_segHcal_noiseLevelElectronicsPileup_mu"+str(puEvents)+".root"
@@ -155,7 +149,9 @@ if bFieldOff:
 from Configurables import ApplicationMgr, FCCDataSvc, PodioInput, PodioOutput
 podioevent = FCCDataSvc("EventDataSvc", input=input_name)
 
-podioinput = PodioInput("PodioReader", collections = inputCollections, OutputLevel = DEBUG)
+podioinput = PodioInput("PodioReader", collections=inputCollections, OutputLevel=DEBUG)
+
+print "Reading collections: ", inputCollections
 
 ##############################################################################################################
 #######                                       CELL POSITIONS  TOOLS                              #############
@@ -299,12 +295,16 @@ if elNoise and not puNoise:
     if not resegmentHCal:
         inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_segHcal_electronicsNoiseLevel.root"
         if addedPU > 0:
-            # no offset, but pu rms 
-            inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_segHcal_noiseLevelElectronicsPileup_mu"+str(addedPU)+".root"
+            # no offset, but rms from  MinBias/simuPU200/ 
+            # input cells already resegmented HCal segmentation
+            inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_electronicsNoiseLevel_forPU"+str(addedPU)+"_recTopo.root"
     else:
         if addedPU > 0:
-            inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_electronicsNoiseLevel_PU"+str(addedPU)+".root"
-
+            # no offset, but rms from  MinBias/simuPU200/                                                                                                                   
+            # input cells already resegmented HCal segmentation                                                                                                             
+            inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/resegmentedHCal/cellNoise_map_electronicsNoiseLevel_forPU"+str(addedPU)+"_recTopo.root"
+            
+            
     print 'Using electronics noise per cell map: ', inputNoisePerCell
         
     from Configurables import CreateCaloCells, NoiseCaloCellsFromFileTool, CalibrateCaloHitsTool, NoiseCaloCellsFlatTool
@@ -731,5 +731,5 @@ ApplicationMgr(
     EvtSel = 'NONE',
     EvtMax   = num_events,
     ExtSvc = [geoservice, podioevent],
-    # OutputLevel = DEBUG
+#    OutputLevel = DEBUG
 )

--- a/python/Convert.py
+++ b/python/Convert.py
@@ -61,19 +61,12 @@ if outfile_name.find("bFieldOn"):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--resegmentedHCal', action='store_true', help="HCal cells are resegmented to deltaEta = 0.025, use different decoder")
-parser.add_argument('--cone', type=float, help='cone size of cells to be included')
 parser.add_argument('--noSignal', action='store_true', help='cone around opposite gen particle eta positions, to extract noise/cell')
 args, _ = parser.parse_known_args()
 
 if args.resegmentedHCal:
     hcalBarrel_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,layer:5,eta:9,phi:10")
     hcalExtBarrel_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,type:2:,layer:4,eta:10,phi:10")
-
-cone = -1
-
-if args.cone:
-    cone = args.cone
-    print 'Output cells/clusters restricted within a cone of R < ', cone
 
 gen_eta = r.std.vector(float)()
 gen_phi = r.std.vector(float)()
@@ -210,217 +203,205 @@ with EventStore([infile_name]) as evs: # p.ex output of Examples/options/simple_
             print 'Using cluster collection "caloClustersBarrel" '
             for c in ev.get("caloClustersBarrel"):
                 position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    cluster_ene.push_back(c.energy())
-                    cluster_eta.push_back(position.Eta())
-                    cluster_phi.push_back(position.Phi())
-                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                    cluster_x.push_back(c.position().x/10.)
-                    cluster_y.push_back(c.position().y/10.)
-                    cluster_z.push_back(c.position().z/10.)
-                    cluster_cells.push_back(c.hits_size())
+                cluster_ene.push_back(c.energy())
+                cluster_eta.push_back(position.Eta())
+                cluster_phi.push_back(position.Phi())
+                cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                cluster_x.push_back(c.position().x/10.)
+                cluster_y.push_back(c.position().y/10.)
+                cluster_z.push_back(c.position().z/10.)
+                cluster_cells.push_back(c.hits_size())
     
         elif ev.get("calibCaloClustersBarrelNoise"):
             print 'Using cluster collection "calibCaloClustersBarrelNoise" '
             for c in ev.get("calibCaloClustersBarrelNoise"):
                 position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    cluster_ene.push_back(c.energy())
-                    cluster_eta.push_back(position.Eta())
-                    cluster_phi.push_back(position.Phi())
-                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                    cluster_x.push_back(c.position().x/10.)
-                    cluster_y.push_back(c.position().y/10.)
-                    cluster_z.push_back(c.position().z/10.)
-                    cluster_cells.push_back(c.hits_size())
+                cluster_ene.push_back(c.energy())
+                cluster_eta.push_back(position.Eta())
+                cluster_phi.push_back(position.Phi())
+                cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                cluster_x.push_back(c.position().x/10.)
+                cluster_y.push_back(c.position().y/10.)
+                cluster_z.push_back(c.position().z/10.)
+                cluster_cells.push_back(c.hits_size())
                     
         elif ev.get("caloClustersBarrelNoise"):
             print 'Using cluster collection "caloClustersBarrelNoise" '
             for c in ev.get("caloClustersBarrelNoise"):
                 position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    cluster_ene.push_back(c.energy())
-                    cluster_eta.push_back(position.Eta())
-                    cluster_phi.push_back(position.Phi())
-                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                    cluster_x.push_back(c.position().x/10.)
-                    cluster_y.push_back(c.position().y/10.)
-                    cluster_z.push_back(c.position().z/10.)
-                    cluster_cells.push_back(c.hits_size())
+                cluster_ene.push_back(c.energy())
+                cluster_eta.push_back(position.Eta())
+                cluster_phi.push_back(position.Phi())
+                cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                cluster_x.push_back(c.position().x/10.)
+                cluster_y.push_back(c.position().y/10.)
+                cluster_z.push_back(c.position().z/10.)
+                cluster_cells.push_back(c.hits_size())
 
         elif ev.get("caloClusters"):
             print 'Using cluster collection "caloClusters" '
             for c in ev.get("caloClusters"):
                 position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    cluster_ene.push_back(c.energy())
-                    cluster_eta.push_back(position.Eta())
-                    cluster_phi.push_back(position.Phi())
-                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                    cluster_x.push_back(c.position().x/10.)
-                    cluster_y.push_back(c.position().y/10.)
-                    cluster_z.push_back(c.position().z/10.)
-                    cluster_cells.push_back(c.hits_size())
+                cluster_ene.push_back(c.energy())
+                cluster_eta.push_back(position.Eta())
+                cluster_phi.push_back(position.Phi())
+                cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                cluster_x.push_back(c.position().x/10.)
+                cluster_y.push_back(c.position().y/10.)
+                cluster_z.push_back(c.position().z/10.)
+                cluster_cells.push_back(c.hits_size())
 
         elif ev.get("caloClustersNoise"):
             print 'Using cluster collection "caloClustersNoise" '
             for c in ev.get("caloClustersNoise"):
                 position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    cluster_ene.push_back(c.energy())
-                    cluster_eta.push_back(position.Eta())
-                    cluster_phi.push_back(position.Phi())
-                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                    cluster_x.push_back(c.position().x/10.)
-                    cluster_y.push_back(c.position().y/10.)
-                    cluster_z.push_back(c.position().z/10.)
-                    cluster_cells.push_back(c.hits_size())
+                cluster_ene.push_back(c.energy())
+                cluster_eta.push_back(position.Eta())
+                cluster_phi.push_back(position.Phi())
+                cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                cluster_x.push_back(c.position().x/10.)
+                cluster_y.push_back(c.position().y/10.)
+                cluster_z.push_back(c.position().z/10.)
+                cluster_cells.push_back(c.hits_size())
                     
         else:
             if ev.get("HCalBarrelCellPositions"):
                 print 'Using cell collection "HCalBarrelCellPositions" '
                 for c in ev.get("HCalBarrelCellPositions"):
                     position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                        rec_ene.push_back(c.energy())
-                        rec_eta.push_back(position.Eta())
-                        rec_phi.push_back(position.Phi())
-                        rec_pt.push_back(c.energy()*position.Unit().Perp())
-                        rec_layer.push_back(hcalBarrel_decoder.get(c.cellId(), "layer") + lastECalBarrelLayer + 1)
-                        rec_x.push_back(c.position().x/10.)
-                        rec_y.push_back(c.position().y/10.)
-                        rec_z.push_back(c.position().z/10.)
-                        rec_detid.push_back(systemID(c.cellId()))
-                        rec_bits.push_back(c.bits())
-                        if hcalBarrel_decoder["layer"] == 0:
-                            EhadFirst += c.energy()
-                        E += c.energy()
-                        Ehad += c.energy()
-                        numHits += 1
+                    recPhi = float(position.Phi())
+                    rec_ene.push_back(c.energy())
+                    rec_eta.push_back(position.Eta())
+                    rec_phi.push_back(position.Phi())
+                    rec_pt.push_back(c.energy()*position.Unit().Perp())
+                    rec_layer.push_back(hcalBarrel_decoder.get(c.cellId(), "layer") + lastECalBarrelLayer + 1)
+                    rec_x.push_back(c.position().x/10.)
+                    rec_y.push_back(c.position().y/10.)
+                    rec_z.push_back(c.position().z/10.)
+                    rec_detid.push_back(systemID(c.cellId()))
+                    rec_bits.push_back(c.bits())
+                    if hcalBarrel_decoder["layer"] == 0:
+                        EhadFirst += c.energy()
+                    E += c.energy()
+                    Ehad += c.energy()
+                    numHits += 1
                         
             if ev.get("ECalBarrelCellPositions"):
                 print 'Using cell collection "ECalBarrelCellPositions" '
                 for c in ev.get("ECalBarrelCellPositions"):
                     position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                        rec_ene.push_back(c.energy())
-                        rec_eta.push_back(position.Eta())
-                        rec_phi.push_back(position.Phi())
-                        rec_pt.push_back(c.energy()*position.Unit().Perp())
-                        rec_layer.push_back(ecalBarrel_decoder.get(c.cellId(), "layer"))
-                        rec_x.push_back(c.position().x/10.)
-                        rec_y.push_back(c.position().y/10.)
-                        rec_z.push_back(c.position().z/10.)
-                        rec_detid.push_back(systemID(c.cellId()))
-                        rec_bits.push_back(c.bits())
-                        if ecalBarrel_decoder["layer"] == lastECalBarrelLayer:
-                            EemLast += c.energy()
-                        E += c.energy()
-                        Eem += c.energy()
-                        numHits += 1
+                    rec_ene.push_back(c.energy())
+                    rec_eta.push_back(position.Eta())
+                    rec_phi.push_back(position.Phi())
+                    rec_pt.push_back(c.energy()*position.Unit().Perp())
+                    rec_layer.push_back(ecalBarrel_decoder.get(c.cellId(), "layer"))
+                    rec_x.push_back(c.position().x/10.)
+                    rec_y.push_back(c.position().y/10.)
+                    rec_z.push_back(c.position().z/10.)
+                    rec_detid.push_back(systemID(c.cellId()))
+                    rec_bits.push_back(c.bits())
+                    if ecalBarrel_decoder["layer"] == lastECalBarrelLayer:
+                        EemLast += c.energy()
+                    E += c.energy()
+                    Eem += c.energy()
+                    numHits += 1
                     
             if ev.get("HCalExtBarrelCellPositions"):
                 for c in ev.get("HCalExtBarrelCellPositions"):
                     position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                        rec_ene.push_back(c.energy())
-                        rec_eta.push_back(position.Eta())
-                        rec_phi.push_back(position.Phi())
-                        rec_pt.push_back(c.energy()*position.Unit().Perp())
-                        rec_layer.push_back(hcalExtBarrel_decoder.get(c.cellId(), "layer") + lastECalBarrelLayer + 1)
-                        rec_x.push_back(c.position().x/10.)
-                        rec_y.push_back(c.position().y/10.)
-                        rec_z.push_back(c.position().z/10.)
-                        rec_detid.push_back(systemID(c.cellId()))
-                        rec_bits.push_back(c.bits())
-                        E += c.energy()
-                        numHits += 1
+                    rec_ene.push_back(c.energy())
+                    rec_eta.push_back(position.Eta())
+                    rec_phi.push_back(position.Phi())
+                    rec_pt.push_back(c.energy()*position.Unit().Perp())
+                    rec_layer.push_back(hcalExtBarrel_decoder.get(c.cellId(), "layer") + lastECalBarrelLayer + 1)
+                    rec_x.push_back(c.position().x/10.)
+                    rec_y.push_back(c.position().y/10.)
+                    rec_z.push_back(c.position().z/10.)
+                    rec_detid.push_back(systemID(c.cellId()))
+                    rec_bits.push_back(c.bits())
+                    E += c.energy()
+                    numHits += 1
             
             if ev.get("ECalEndcapCellPositions"):
                 for c in ev.get("ECalEndcapCellPositions"):
                     position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                        rec_ene.push_back(c.energy())
-                        rec_eta.push_back(position.Eta())
-                        rec_phi.push_back(position.Phi())
-                        rec_pt.push_back(c.energy()*position.Unit().Perp())
-                        rec_layer.push_back(ecalEndcap_decoder.get(c.cellId(), "layer"))
-                        rec_x.push_back(c.position().x/10.)
-                        rec_y.push_back(c.position().y/10.)
-                        rec_z.push_back(c.position().z/10.)
-                        rec_detid.push_back(systemID(c.cellId()))
-                        rec_bits.push_back(c.bits())
-                        E += c.energy()
-                        numHits += 1
+                    rec_ene.push_back(c.energy())
+                    rec_eta.push_back(position.Eta())
+                    rec_phi.push_back(position.Phi())
+                    rec_pt.push_back(c.energy()*position.Unit().Perp())
+                    rec_layer.push_back(ecalEndcap_decoder.get(c.cellId(), "layer"))
+                    rec_x.push_back(c.position().x/10.)
+                    rec_y.push_back(c.position().y/10.)
+                    rec_z.push_back(c.position().z/10.)
+                    rec_detid.push_back(systemID(c.cellId()))
+                    rec_bits.push_back(c.bits())
+                    E += c.energy()
+                    numHits += 1
                         
             if ev.get("HCalEndcapCellPositions"):
                 for c in ev.get("HCalEndcapCellPositions"):
                     position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                        rec_ene.push_back(c.energy())
-                        rec_eta.push_back(position.Eta())
-                        rec_phi.push_back(position.Phi())
-                        rec_pt.push_back(c.energy()*position.Unit().Perp())
-                        rec_layer.push_back(hcalEndcap_decoder.get(c.cellId(), "layer") + lastECalEndcapLayer + 1)
-                        rec_x.push_back(c.position().x/10.)
-                        rec_y.push_back(c.position().y/10.)
-                        rec_z.push_back(c.position().z/10.)
-                        rec_detid.push_back(systemID(c.cellId()))
-                        rec_bits.push_back(c.bits())
-                        E += c.energy()
-                        numHits += 1
+                    rec_ene.push_back(c.energy())
+                    rec_eta.push_back(position.Eta())
+                    rec_phi.push_back(position.Phi())
+                    rec_pt.push_back(c.energy()*position.Unit().Perp())
+                    rec_layer.push_back(hcalEndcap_decoder.get(c.cellId(), "layer") + lastECalEndcapLayer + 1)
+                    rec_x.push_back(c.position().x/10.)
+                    rec_y.push_back(c.position().y/10.)
+                    rec_z.push_back(c.position().z/10.)
+                    rec_detid.push_back(systemID(c.cellId()))
+                    rec_bits.push_back(c.bits())
+                    E += c.energy()
+                    numHits += 1
                         
             if ev.get("ECalFwdCellPositions"):
                 for c in ev.get("ECalFwdCellPositions"):
                     position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                        rec_ene.push_back(c.energy())
-                        rec_eta.push_back(position.Eta())
-                        rec_phi.push_back(position.Phi())
-                        rec_pt.push_back(c.energy()*position.Unit().Perp())
-                        rec_layer.push_back(ecalFwd_decoder.get(c.cellId(), "layer"))
-                        rec_x.push_back(c.position().x/10.)
-                        rec_y.push_back(c.position().y/10.)
-                        rec_z.push_back(c.position().z/10.)
-                        rec_detid.push_back(systemID(c.cellId()))
-                        rec_bits.push_back(c.bits())
-                        E += c.energy()
-                        numHits += 1
+                    rec_ene.push_back(c.energy())
+                    rec_eta.push_back(position.Eta())
+                    rec_phi.push_back(position.Phi())
+                    rec_pt.push_back(c.energy()*position.Unit().Perp())
+                    rec_layer.push_back(ecalFwd_decoder.get(c.cellId(), "layer"))
+                    rec_x.push_back(c.position().x/10.)
+                    rec_y.push_back(c.position().y/10.)
+                    rec_z.push_back(c.position().z/10.)
+                    rec_detid.push_back(systemID(c.cellId()))
+                    rec_bits.push_back(c.bits())
+                    E += c.energy()
+                    numHits += 1
                     
             if ev.get("HCalFwdCellPositions"):
                 for c in ev.get("HCalFwdCellPositions"):
                     position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                        rec_ene.push_back(c.energy())
-                        rec_eta.push_back(position.Eta())
-                        rec_phi.push_back(position.Phi())
-                        rec_pt.push_back(c.energy()*position.Unit().Perp())
-                        rec_layer.push_back(hcalFwd_decoder.get(c.cellId(), "layer") + lastECalFwdLayer + 1)
-                        rec_x.push_back(c.position().x/10.)
-                        rec_y.push_back(c.position().y/10.)
-                        rec_z.push_back(c.position().z/10.)
-                        rec_detid.push_back(systemID(c.cellId()))
-                        rec_bits.push_back(c.bits())
-                        E += c.energy()
-                        numHits += 1
+                    rec_ene.push_back(c.energy())
+                    rec_eta.push_back(position.Eta())
+                    rec_phi.push_back(position.Phi())
+                    rec_pt.push_back(c.energy()*position.Unit().Perp())
+                    rec_layer.push_back(hcalFwd_decoder.get(c.cellId(), "layer") + lastECalFwdLayer + 1)
+                    rec_x.push_back(c.position().x/10.)
+                    rec_y.push_back(c.position().y/10.)
+                    rec_z.push_back(c.position().z/10.)
+                    rec_detid.push_back(systemID(c.cellId()))
+                    rec_bits.push_back(c.bits())
+                    E += c.energy()
+                    numHits += 1
 
 
             if ev.get("HCalPositionedHits"):
                 for c in ev.get("HCalPositionedHits"):
                     position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                        rec_ene.push_back(c.energy())
-                        rec_eta.push_back(position.Eta())
-                        rec_phi.push_back(position.Phi())
-                        rec_pt.push_back(c.energy()*position.Unit().Perp())
-                        rec_layer.push_back(ecalFwd_decoder.get(c.cellId(), "layer"))
-                        rec_x.push_back(c.position().x/10.)
-                        rec_y.push_back(c.position().y/10.)
-                        rec_z.push_back(c.position().z/10.)
-                        rec_detid.push_back(systemID(c.cellId()))
-                        rec_bits.push_back(c.bits())
-                        E += c.energy()
-                        numHits += 1
+                    rec_ene.push_back(c.energy())
+                    rec_eta.push_back(position.Eta())
+                    rec_phi.push_back(position.Phi())
+                    rec_pt.push_back(c.energy()*position.Unit().Perp())
+                    rec_layer.push_back(ecalFwd_decoder.get(c.cellId(), "layer"))
+                    rec_x.push_back(c.position().x/10.)
+                    rec_y.push_back(c.position().y/10.)
+                    rec_z.push_back(c.position().z/10.)
+                    rec_detid.push_back(systemID(c.cellId()))
+                    rec_bits.push_back(c.bits())
+                    E += c.energy()
+                    numHits += 1
 
             if ev.get("TrackerPositionedHits"):
                 for c in ev.get("TrackerPositionedHits"):

--- a/python/Convert.py
+++ b/python/Convert.py
@@ -152,343 +152,347 @@ outtree.Branch("gen_bits", gen_bits)
 
 numEvent = 0
 with EventStore([infile_name]) as evs: # p.ex output of Examples/options/simple_pythia.py
-    event = evs[0]
-    ev_num[0] = numEvent
-    numHits = 0
-    E = .0
-    Ebench = .0
-    Eem = .0
-    Ehad = .0
-    EemLast = .0
-    EhadFirst = .0
-    etaGen = .0
-    phiGen = .0
-    energyGen = .0 
-
-    for g in event.get("GenParticles"):
-        if g.status() == 1:
-            position = r.TVector3(g.p4().px,g.p4().py,g.p4().pz)
-
-            gen_x.push_back(g.startVertex().x()/10.)
-            gen_y.push_back(g.startVertex().y()/10.)
-            gen_z.push_back(g.startVertex().z()/10.)
-
-            pt=math.sqrt(g.p4().px**2+g.p4().py**2)
-            eta=position.Eta()
-            phi=position.Phi()
-            
-            tlv=r.TLorentzVector()
-            tlv.SetPtEtaPhiM(pt,eta,phi,g.p4().mass)
-            gen_pt.push_back(pt)
-            gen_eta.push_back(eta)
-            gen_phi.push_back(phi)
-            gen_energy.push_back(math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2))
-            gen_bits.push_back(g.bits())
-
-            etaGen += eta*math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2)
-            phiGen += phi*math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2)
-            energyGen += math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2)
-
-            if math.fabs(tlv.E()-math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2))>0.01 and g.status==1:
-                print '=======================etlv  ',tlv.E(),'    ',math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2),'  eta  ',eta,'   phi   ',phi,'  x  ',g.p4().px,'  y  ',g.p4().py,'  z  ',g.p4().pz
-            gen_pdgid.push_back(g.pdgId())
-            gen_status.push_back(g.status())
-            
-    if energyGen != 0.:
-        etaGen = float(etaGen)/float(energyGen)
-        phiGen = float(phiGen)/float(energyGen)
+    for ev in evs:
         
-    if args.noSignal:
-        etaGen = -etaGen
-        phiGen = -phiGen
-
-    print 'gen particle:  ', etaGen,phiGen,energyGen
-    
-    if event.get("caloClustersBarrel"):
-        print 'Using cluster collection "caloClustersBarrel" '
-        for c in event.get("caloClustersBarrel"):
-            position = r.TVector3(c.position().x,c.position().y,c.position().z)
-            if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                cluster_ene.push_back(c.energy())
-                cluster_eta.push_back(position.Eta())
-                cluster_phi.push_back(position.Phi())
-                cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                cluster_x.push_back(c.position().x/10.)
-                cluster_y.push_back(c.position().y/10.)
-                cluster_z.push_back(c.position().z/10.)
-                cluster_cells.push_back(c.hits_size())
-
-    elif event.get("calibCaloClustersBarrelNoise"):
-        print 'Using cluster collection "calibCaloClustersBarrelNoise" '
-        for c in event.get("calibCaloClustersBarrelNoise"):
-            position = r.TVector3(c.position().x,c.position().y,c.position().z)
-            if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                cluster_ene.push_back(c.energy())
-                cluster_eta.push_back(position.Eta())
-                cluster_phi.push_back(position.Phi())
-                cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                cluster_x.push_back(c.position().x/10.)
-                cluster_y.push_back(c.position().y/10.)
-                cluster_z.push_back(c.position().z/10.)
-                cluster_cells.push_back(c.hits_size())
-
-    elif event.get("caloClustersBarrelNoise"):
-        print 'Using cluster collection "caloClustersBarrelNoise" '
-        for c in event.get("caloClustersBarrelNoise"):
-            position = r.TVector3(c.position().x,c.position().y,c.position().z)
-            if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                cluster_ene.push_back(c.energy())
-                cluster_eta.push_back(position.Eta())
-                cluster_phi.push_back(position.Phi())
-                cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                cluster_x.push_back(c.position().x/10.)
-                cluster_y.push_back(c.position().y/10.)
-                cluster_z.push_back(c.position().z/10.)
-                cluster_cells.push_back(c.hits_size())
-
-    elif event.get("caloClusters"):
-        print 'Using cluster collection "caloClusters" '
-        for c in event.get("caloClusters"):
-            position = r.TVector3(c.position().x,c.position().y,c.position().z)
-            if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                cluster_ene.push_back(c.energy())
-                cluster_eta.push_back(position.Eta())
-                cluster_phi.push_back(position.Phi())
-                cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                cluster_x.push_back(c.position().x/10.)
-                cluster_y.push_back(c.position().y/10.)
-                cluster_z.push_back(c.position().z/10.)
-                cluster_cells.push_back(c.hits_size())
-
-    elif event.get("caloClustersNoise"):
-        print 'Using cluster collection "caloClustersNoise" '
-        for c in event.get("caloClustersNoise"):
-            position = r.TVector3(c.position().x,c.position().y,c.position().z)
-            if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                cluster_ene.push_back(c.energy())
-                cluster_eta.push_back(position.Eta())
-                cluster_phi.push_back(position.Phi())
-                cluster_pt.push_back(c.energy()*position.Unit().Perp())
-                cluster_x.push_back(c.position().x/10.)
-                cluster_y.push_back(c.position().y/10.)
-                cluster_z.push_back(c.position().z/10.)
-                cluster_cells.push_back(c.hits_size())
-
-    else:
-        if event.get("HCalBarrelCellPositions"):
-            for c in event.get("HCalBarrelCellPositions"):
-                position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    rec_ene.push_back(c.energy())
-                    rec_eta.push_back(position.Eta())
-                    rec_phi.push_back(position.Phi())
-                    rec_pt.push_back(c.energy()*position.Unit().Perp())
-                    rec_layer.push_back(hcalBarrel_decoder.get(c.cellId(), "layer") + lastECalBarrelLayer + 1)
-                    rec_x.push_back(c.position().x/10.)
-                    rec_y.push_back(c.position().y/10.)
-                    rec_z.push_back(c.position().z/10.)
-                    rec_detid.push_back(systemID(c.cellId()))
-                    rec_bits.push_back(c.bits())
-                    if hcalBarrel_decoder["layer"] == 0:
-                        EhadFirst += c.energy()
-                    E += c.energy()
-                    Ehad += c.energy()
-                    numHits += 1
-    
-        if event.get("ECalBarrelCellPositions"):
-            for c in event.get("ECalBarrelCellPositions"):
-                position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    rec_ene.push_back(c.energy())
-                    rec_eta.push_back(position.Eta())
-                    rec_phi.push_back(position.Phi())
-                    rec_pt.push_back(c.energy()*position.Unit().Perp())
-                    rec_layer.push_back(ecalBarrel_decoder.get(c.cellId(), "layer"))
-                    rec_x.push_back(c.position().x/10.)
-                    rec_y.push_back(c.position().y/10.)
-                    rec_z.push_back(c.position().z/10.)
-                    rec_detid.push_back(systemID(c.cellId()))
-                    rec_bits.push_back(c.bits())
-                    if ecalBarrel_decoder["layer"] == lastECalBarrelLayer:
-                        EemLast += c.energy()
-                    E += c.energy()
-                    Eem += c.energy()
-                    numHits += 1
+        ev_num[0] = numEvent
+        numHits = 0
+        E = .0
+        Ebench = .0
+        Eem = .0
+        Ehad = .0
+        EemLast = .0
+        EhadFirst = .0
+        etaGen = .0
+        phiGen = .0
+        energyGen = .0 
+        
+        if ev.get("GenParticles"):
+            for g in ev.get("GenParticles"):
+                if g.status() == 1:
+                    position = r.TVector3(g.p4().px,g.p4().py,g.p4().pz)
                     
-        if event.get("HCalExtBarrelCellPositions"):
-            for c in event.get("HCalExtBarrelCellPositions"):
+                    gen_x.push_back(g.startVertex().x()/10.)
+                    gen_y.push_back(g.startVertex().y()/10.)
+                    gen_z.push_back(g.startVertex().z()/10.)
+                    
+                    pt=math.sqrt(g.p4().px**2+g.p4().py**2)
+                    eta=position.Eta()
+                    phi=position.Phi()
+                    
+                    tlv=r.TLorentzVector()
+                    tlv.SetPtEtaPhiM(pt,eta,phi,g.p4().mass)
+                    gen_pt.push_back(pt)
+                    gen_eta.push_back(eta)
+                    gen_phi.push_back(phi)
+                    gen_energy.push_back(math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2))
+                    gen_bits.push_back(g.bits())
+                    
+                    etaGen += eta*math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2)
+                    phiGen += phi*math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2)
+                    energyGen += math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2)
+                    
+                    if math.fabs(tlv.E()-math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2))>0.01 and g.status==1:
+                        print '=======================etlv  ',tlv.E(),'    ',math.sqrt(g.p4().mass**2+g.p4().px**2+g.p4().py**2+g.p4().pz**2),'  eta  ',eta,'   phi   ',phi,'  x  ',g.p4().px,'  y  ',g.p4().py,'  z  ',g.p4().pz
+                        gen_pdgid.push_back(g.pdgId())
+                        gen_status.push_back(g.status())
+                        
+                    if energyGen != 0.:
+                        etaGen = float(etaGen)/float(energyGen)
+                        phiGen = float(phiGen)/float(energyGen)
+                        
+                    if args.noSignal:
+                        etaGen = -etaGen
+                        phiGen = -phiGen
+
+            print 'gen particle:  ', etaGen,phiGen,energyGen
+    
+        if ev.get("caloClustersBarrel"):
+            print 'Using cluster collection "caloClustersBarrel" '
+            for c in ev.get("caloClustersBarrel"):
                 position = r.TVector3(c.position().x,c.position().y,c.position().z)
                 if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    rec_ene.push_back(c.energy())
-                    rec_eta.push_back(position.Eta())
-                    rec_phi.push_back(position.Phi())
-                    rec_pt.push_back(c.energy()*position.Unit().Perp())
-                    rec_layer.push_back(hcalExtBarrel_decoder.get(c.cellId(), "layer") + lastECalBarrelLayer + 1)
-                    rec_x.push_back(c.position().x/10.)
-                    rec_y.push_back(c.position().y/10.)
-                    rec_z.push_back(c.position().z/10.)
-                    rec_detid.push_back(systemID(c.cellId()))
-                    rec_bits.push_back(c.bits())
-                    E += c.energy()
-                    numHits += 1
+                    cluster_ene.push_back(c.energy())
+                    cluster_eta.push_back(position.Eta())
+                    cluster_phi.push_back(position.Phi())
+                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                    cluster_x.push_back(c.position().x/10.)
+                    cluster_y.push_back(c.position().y/10.)
+                    cluster_z.push_back(c.position().z/10.)
+                    cluster_cells.push_back(c.hits_size())
+    
+        elif ev.get("calibCaloClustersBarrelNoise"):
+            print 'Using cluster collection "calibCaloClustersBarrelNoise" '
+            for c in ev.get("calibCaloClustersBarrelNoise"):
+                position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                    cluster_ene.push_back(c.energy())
+                    cluster_eta.push_back(position.Eta())
+                    cluster_phi.push_back(position.Phi())
+                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                    cluster_x.push_back(c.position().x/10.)
+                    cluster_y.push_back(c.position().y/10.)
+                    cluster_z.push_back(c.position().z/10.)
+                    cluster_cells.push_back(c.hits_size())
+                    
+        elif ev.get("caloClustersBarrelNoise"):
+            print 'Using cluster collection "caloClustersBarrelNoise" '
+            for c in ev.get("caloClustersBarrelNoise"):
+                position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                    cluster_ene.push_back(c.energy())
+                    cluster_eta.push_back(position.Eta())
+                    cluster_phi.push_back(position.Phi())
+                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                    cluster_x.push_back(c.position().x/10.)
+                    cluster_y.push_back(c.position().y/10.)
+                    cluster_z.push_back(c.position().z/10.)
+                    cluster_cells.push_back(c.hits_size())
+
+        elif ev.get("caloClusters"):
+            print 'Using cluster collection "caloClusters" '
+            for c in ev.get("caloClusters"):
+                position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                    cluster_ene.push_back(c.energy())
+                    cluster_eta.push_back(position.Eta())
+                    cluster_phi.push_back(position.Phi())
+                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                    cluster_x.push_back(c.position().x/10.)
+                    cluster_y.push_back(c.position().y/10.)
+                    cluster_z.push_back(c.position().z/10.)
+                    cluster_cells.push_back(c.hits_size())
+
+        elif ev.get("caloClustersNoise"):
+            print 'Using cluster collection "caloClustersNoise" '
+            for c in ev.get("caloClustersNoise"):
+                position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                    cluster_ene.push_back(c.energy())
+                    cluster_eta.push_back(position.Eta())
+                    cluster_phi.push_back(position.Phi())
+                    cluster_pt.push_back(c.energy()*position.Unit().Perp())
+                    cluster_x.push_back(c.position().x/10.)
+                    cluster_y.push_back(c.position().y/10.)
+                    cluster_z.push_back(c.position().z/10.)
+                    cluster_cells.push_back(c.hits_size())
+                    
+        else:
+            if ev.get("HCalBarrelCellPositions"):
+                print 'Using cell collection "HCalBarrelCellPositions" '
+                for c in ev.get("HCalBarrelCellPositions"):
+                    position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                        rec_ene.push_back(c.energy())
+                        rec_eta.push_back(position.Eta())
+                        rec_phi.push_back(position.Phi())
+                        rec_pt.push_back(c.energy()*position.Unit().Perp())
+                        rec_layer.push_back(hcalBarrel_decoder.get(c.cellId(), "layer") + lastECalBarrelLayer + 1)
+                        rec_x.push_back(c.position().x/10.)
+                        rec_y.push_back(c.position().y/10.)
+                        rec_z.push_back(c.position().z/10.)
+                        rec_detid.push_back(systemID(c.cellId()))
+                        rec_bits.push_back(c.bits())
+                        if hcalBarrel_decoder["layer"] == 0:
+                            EhadFirst += c.energy()
+                        E += c.energy()
+                        Ehad += c.energy()
+                        numHits += 1
+                        
+            if ev.get("ECalBarrelCellPositions"):
+                print 'Using cell collection "ECalBarrelCellPositions" '
+                for c in ev.get("ECalBarrelCellPositions"):
+                    position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                        rec_ene.push_back(c.energy())
+                        rec_eta.push_back(position.Eta())
+                        rec_phi.push_back(position.Phi())
+                        rec_pt.push_back(c.energy()*position.Unit().Perp())
+                        rec_layer.push_back(ecalBarrel_decoder.get(c.cellId(), "layer"))
+                        rec_x.push_back(c.position().x/10.)
+                        rec_y.push_back(c.position().y/10.)
+                        rec_z.push_back(c.position().z/10.)
+                        rec_detid.push_back(systemID(c.cellId()))
+                        rec_bits.push_back(c.bits())
+                        if ecalBarrel_decoder["layer"] == lastECalBarrelLayer:
+                            EemLast += c.energy()
+                        E += c.energy()
+                        Eem += c.energy()
+                        numHits += 1
+                    
+            if ev.get("HCalExtBarrelCellPositions"):
+                for c in ev.get("HCalExtBarrelCellPositions"):
+                    position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                        rec_ene.push_back(c.energy())
+                        rec_eta.push_back(position.Eta())
+                        rec_phi.push_back(position.Phi())
+                        rec_pt.push_back(c.energy()*position.Unit().Perp())
+                        rec_layer.push_back(hcalExtBarrel_decoder.get(c.cellId(), "layer") + lastECalBarrelLayer + 1)
+                        rec_x.push_back(c.position().x/10.)
+                        rec_y.push_back(c.position().y/10.)
+                        rec_z.push_back(c.position().z/10.)
+                        rec_detid.push_back(systemID(c.cellId()))
+                        rec_bits.push_back(c.bits())
+                        E += c.energy()
+                        numHits += 1
             
-        if event.get("ECalEndcapCellPositions"):
-            for c in event.get("ECalEndcapCellPositions"):
-                position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+            if ev.get("ECalEndcapCellPositions"):
+                for c in ev.get("ECalEndcapCellPositions"):
+                    position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                        rec_ene.push_back(c.energy())
+                        rec_eta.push_back(position.Eta())
+                        rec_phi.push_back(position.Phi())
+                        rec_pt.push_back(c.energy()*position.Unit().Perp())
+                        rec_layer.push_back(ecalEndcap_decoder.get(c.cellId(), "layer"))
+                        rec_x.push_back(c.position().x/10.)
+                        rec_y.push_back(c.position().y/10.)
+                        rec_z.push_back(c.position().z/10.)
+                        rec_detid.push_back(systemID(c.cellId()))
+                        rec_bits.push_back(c.bits())
+                        E += c.energy()
+                        numHits += 1
+                        
+            if ev.get("HCalEndcapCellPositions"):
+                for c in ev.get("HCalEndcapCellPositions"):
+                    position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                        rec_ene.push_back(c.energy())
+                        rec_eta.push_back(position.Eta())
+                        rec_phi.push_back(position.Phi())
+                        rec_pt.push_back(c.energy()*position.Unit().Perp())
+                        rec_layer.push_back(hcalEndcap_decoder.get(c.cellId(), "layer") + lastECalEndcapLayer + 1)
+                        rec_x.push_back(c.position().x/10.)
+                        rec_y.push_back(c.position().y/10.)
+                        rec_z.push_back(c.position().z/10.)
+                        rec_detid.push_back(systemID(c.cellId()))
+                        rec_bits.push_back(c.bits())
+                        E += c.energy()
+                        numHits += 1
+                        
+            if ev.get("ECalFwdCellPositions"):
+                for c in ev.get("ECalFwdCellPositions"):
+                    position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                        rec_ene.push_back(c.energy())
+                        rec_eta.push_back(position.Eta())
+                        rec_phi.push_back(position.Phi())
+                        rec_pt.push_back(c.energy()*position.Unit().Perp())
+                        rec_layer.push_back(ecalFwd_decoder.get(c.cellId(), "layer"))
+                        rec_x.push_back(c.position().x/10.)
+                        rec_y.push_back(c.position().y/10.)
+                        rec_z.push_back(c.position().z/10.)
+                        rec_detid.push_back(systemID(c.cellId()))
+                        rec_bits.push_back(c.bits())
+                        E += c.energy()
+                        numHits += 1
+                    
+            if ev.get("HCalFwdCellPositions"):
+                for c in ev.get("HCalFwdCellPositions"):
+                    position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                        rec_ene.push_back(c.energy())
+                        rec_eta.push_back(position.Eta())
+                        rec_phi.push_back(position.Phi())
+                        rec_pt.push_back(c.energy()*position.Unit().Perp())
+                        rec_layer.push_back(hcalFwd_decoder.get(c.cellId(), "layer") + lastECalFwdLayer + 1)
+                        rec_x.push_back(c.position().x/10.)
+                        rec_y.push_back(c.position().y/10.)
+                        rec_z.push_back(c.position().z/10.)
+                        rec_detid.push_back(systemID(c.cellId()))
+                        rec_bits.push_back(c.bits())
+                        E += c.energy()
+                        numHits += 1
+
+
+            if ev.get("HCalPositionedHits"):
+                for c in ev.get("HCalPositionedHits"):
+                    position = r.TVector3(c.position().x,c.position().y,c.position().z)
+                    if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
+                        rec_ene.push_back(c.energy())
+                        rec_eta.push_back(position.Eta())
+                        rec_phi.push_back(position.Phi())
+                        rec_pt.push_back(c.energy()*position.Unit().Perp())
+                        rec_layer.push_back(ecalFwd_decoder.get(c.cellId(), "layer"))
+                        rec_x.push_back(c.position().x/10.)
+                        rec_y.push_back(c.position().y/10.)
+                        rec_z.push_back(c.position().z/10.)
+                        rec_detid.push_back(systemID(c.cellId()))
+                        rec_bits.push_back(c.bits())
+                        E += c.energy()
+                        numHits += 1
+
+            if ev.get("TrackerPositionedHits"):
+                for c in ev.get("TrackerPositionedHits"):
+                    position = r.TVector3(c.position().x,c.position().y,c.position().z)
                     rec_ene.push_back(c.energy())
                     rec_eta.push_back(position.Eta())
                     rec_phi.push_back(position.Phi())
                     rec_pt.push_back(c.energy()*position.Unit().Perp())
-                    rec_layer.push_back(ecalEndcap_decoder.get(c.cellId(), "layer"))
-                    rec_x.push_back(c.position().x/10.)
-                    rec_y.push_back(c.position().y/10.)
-                    rec_z.push_back(c.position().z/10.)
-                    rec_detid.push_back(systemID(c.cellId()))
-                    rec_bits.push_back(c.bits())
-                    E += c.energy()
-                    numHits += 1
-
-        if event.get("HCalEndcapCellPositions"):
-            for c in event.get("HCalEndcapCellPositions"):
-                position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    rec_ene.push_back(c.energy())
-                    rec_eta.push_back(position.Eta())
-                    rec_phi.push_back(position.Phi())
-                    rec_pt.push_back(c.energy()*position.Unit().Perp())
-                    rec_layer.push_back(hcalEndcap_decoder.get(c.cellId(), "layer") + lastECalEndcapLayer + 1)
-                    rec_x.push_back(c.position().x/10.)
-                    rec_y.push_back(c.position().y/10.)
-                    rec_z.push_back(c.position().z/10.)
-                    rec_detid.push_back(systemID(c.cellId()))
-                    rec_bits.push_back(c.bits())
-                    E += c.energy()
-                    numHits += 1
-                
-        if event.get("ECalFwdCellPositions"):
-            for c in event.get("ECalFwdCellPositions"):
-                position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    rec_ene.push_back(c.energy())
-                    rec_eta.push_back(position.Eta())
-                    rec_phi.push_back(position.Phi())
-                    rec_pt.push_back(c.energy()*position.Unit().Perp())
-                    rec_layer.push_back(ecalFwd_decoder.get(c.cellId(), "layer"))
-                    rec_x.push_back(c.position().x/10.)
-                    rec_y.push_back(c.position().y/10.)
-                    rec_z.push_back(c.position().z/10.)
-                    rec_detid.push_back(systemID(c.cellId()))
-                    rec_bits.push_back(c.bits())
-                    E += c.energy()
-                    numHits += 1
-
-        if event.GetBranchStatus("HCalFwdCellPositions"):
-            for c in event.HCalFwdCellPositions:
-                position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    rec_ene.push_back(c.energy())
-                    rec_eta.push_back(position.Eta())
-                    rec_phi.push_back(position.Phi())
-                    rec_pt.push_back(c.energy()*position.Unit().Perp())
-                    rec_layer.push_back(hcalFwd_decoder.get(c.cellId(), "layer") + lastECalFwdLayer + 1)
-                    rec_x.push_back(c.position().x/10.)
-                    rec_y.push_back(c.position().y/10.)
-                    rec_z.push_back(c.position().z/10.)
-                    rec_detid.push_back(systemID(c.cellId()))
-                    rec_bits.push_back(c.bits())
-                    E += c.energy()
-                    numHits += 1
-
-
-        if event.get("HCalPositionedHits"):
-            for c in event.get("HCalPositionedHits"):
-                position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                if (cone>0 and float(math.sqrt(math.pow((position.Eta()-etaGen), 2)+math.pow((position.Phi()-phiGen), 2))) < cone) or cone<0:
-                    rec_ene.push_back(c.energy())
-                    rec_eta.push_back(position.Eta())
-                    rec_phi.push_back(position.Phi())
-                    rec_pt.push_back(c.energy()*position.Unit().Perp())
-                    rec_layer.push_back(ecalFwd_decoder.get(c.cellId(), "layer"))
-                    rec_x.push_back(c.position().x/10.)
-                    rec_y.push_back(c.position().y/10.)
-                    rec_z.push_back(c.position().z/10.)
-                    rec_detid.push_back(systemID(c.cellId()))
-                    rec_bits.push_back(c.bits())
-                    E += c.energy()
-                    numHits += 1
-
-        if event.get("TrackerPositionedHits"):
-            for c in event.get("TrackerPositionedHits"):
-                position = r.TVector3(c.position().x,c.position().y,c.position().z)
-                rec_ene.push_back(c.energy())
-                rec_eta.push_back(position.Eta())
-                rec_phi.push_back(position.Phi())
-                rec_pt.push_back(c.energy()*position.Unit().Perp())
-                sysID = systemID(c.cellId())
-                if  sysID == 0 :
-                    rec_layer.push_back(trackerBarrel_decoder["layer"])
-                elif sysID == 1 :
-                    rec_layer.push_back(trackerBarrel_decoder["layer"] + lastInnerTrackerBarrelLayer + 1)
-                elif sysID == 2 :
-                    posneg = trackerEndcap_decoder["posneg"]
-                    if posneg == 0 :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastOuterTrackerBarrelLayer + 1)
+                    sysID = systemID(c.cellId())
+                    if  sysID == 0 :
+                        rec_layer.push_back(trackerBarrel_decoder["layer"])
+                    elif sysID == 1 :
+                        rec_layer.push_back(trackerBarrel_decoder["layer"] + lastInnerTrackerBarrelLayer + 1)
+                    elif sysID == 2 :
+                        posneg = trackerEndcap_decoder["posneg"]
+                        if posneg == 0 :
+                            rec_layer.push_back(trackerEndcap_decoder["disc"] + lastOuterTrackerBarrelLayer + 1)
+                        else :
+                            rec_layer.push_back(trackerEndcap_decoder["disc"] + lastInnerTrackerPosECapLayer + 1)
+                    elif sysID == 3:
+                        posneg = trackerEndcap_decoder["posneg"]
+                        if posneg == 0 :
+                            rec_layer.push_back(trackerEndcap_decoder["disc"] + lastInnerTrackerNegECapLayer + 1)
+                        else :
+                            rec_layer.push_back(trackerEndcap_decoder["disc"] + lastOuterTrackerPosECapLayer + 1)
                     else :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastInnerTrackerPosECapLayer + 1)
-                elif sysID == 3:
-                    posneg = trackerEndcap_decoder["posneg"]
-                    if posneg == 0 :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastInnerTrackerNegECapLayer + 1)
-                    else :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastOuterTrackerPosECapLayer + 1)
-                else :
-                    posneg = trackerEndcap_decoder["posneg"]
-                    if posneg == 0 :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastOuterTrackerNegECapLayer + 1)
-                    else :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastFwdTrackerPosECapLayer + 1)
-                rec_x.push_back(c.position().x/10.)
-                rec_y.push_back(c.position().y/10.)
-                rec_z.push_back(c.position().z/10.)
-                rec_detid.push_back(systemID(c.cellId()))
-                rec_bits.push_back(c.bits())
-                E += c.energy()
-                numHits += 1
-
-    ev_ebench[0] = benchmarkCorr(Eem,EemLast,Ehad,EhadFirst,a,b,c1)
-    ev_e[0] = E
-    ev_nRechits[0] = numHits
-    
-    outtree.Fill()
-
-    gen_eta.clear()
-    gen_phi.clear()
-    gen_pt.clear()
-    gen_energy.clear()
-    gen_pdgid.clear()
-    gen_status.clear()
-
-    cluster_eta.clear()
-    cluster_phi.clear()
-    cluster_pt.clear()
-    cluster_ene.clear()
-    cluster_x.clear()
-    cluster_y.clear()
-    cluster_z.clear()
-    
-    rec_eta.clear()
-    rec_phi.clear()
-    rec_pt.clear()
-    rec_ene.clear()
-    rec_layer.clear()
-    rec_x.clear()
-    rec_y.clear()
-    rec_z.clear()
-    rec_detid.clear()
-    rec_bits.clear()
-    
-    numEvent += 1
+                        posneg = trackerEndcap_decoder["posneg"]
+                        if posneg == 0 :
+                            rec_layer.push_back(trackerEndcap_decoder["disc"] + lastOuterTrackerNegECapLayer + 1)
+                        else :
+                            rec_layer.push_back(trackerEndcap_decoder["disc"] + lastFwdTrackerPosECapLayer + 1)
+                            rec_x.push_back(c.position().x/10.)
+                            rec_y.push_back(c.position().y/10.)
+                            rec_z.push_back(c.position().z/10.)
+                            rec_detid.push_back(systemID(c.cellId()))
+                            rec_bits.push_back(c.bits())
+                            E += c.energy()
+                            numHits += 1
+                            
+        ev_ebench[0] = benchmarkCorr(Eem,EemLast,Ehad,EhadFirst,a,b,c1)
+        ev_e[0] = E
+        ev_nRechits[0] = numHits
+        
+        outtree.Fill()
+        
+        gen_eta.clear()
+        gen_phi.clear()
+        gen_pt.clear()
+        gen_energy.clear()
+        gen_pdgid.clear()
+        gen_status.clear()
+        
+        cluster_eta.clear()
+        cluster_phi.clear()
+        cluster_pt.clear()
+        cluster_ene.clear()
+        cluster_x.clear()
+        cluster_y.clear()
+        cluster_z.clear()
+        
+        rec_eta.clear()
+        rec_phi.clear()
+        rec_pt.clear()
+        rec_ene.clear()
+        rec_layer.clear()
+        rec_x.clear()
+        rec_y.clear()
+        rec_z.clear()
+        rec_detid.clear()
+        rec_bits.clear()
+        
+        numEvent += 1
 
 outfile.Write()
 outfile.Close()

--- a/python/Convert.py
+++ b/python/Convert.py
@@ -59,6 +59,9 @@ if outfile_name.find("bFieldOn"):
     b=0.565
     c1=-0.00000074
 
+rminECal = 175
+bField = 4
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--resegmentedHCal', action='store_true', help="HCal cells are resegmented to deltaEta = 0.025, use different decoder")
 parser.add_argument('--noSignal', action='store_true', help='cone around opposite gen particle eta positions, to extract noise/cell')
@@ -169,6 +172,14 @@ with EventStore([infile_name]) as evs: # p.ex output of Examples/options/simple_
                     gen_z.push_back(g.startVertex().z()/10.)
                     
                     pt=math.sqrt(g.p4().px**2+g.p4().py**2)
+                    radius=pt/0.3/bField
+                    
+                    if g.charge()!=0:
+                        print "_____________________"
+                        print "Particle pt :    ", pt
+                        print "Particle charge: ", g.charge()
+                        print "Helix radius:    ", radius
+                    
                     eta=position.Eta()
                     phi=position.Phi()
                     
@@ -454,6 +465,7 @@ with EventStore([infile_name]) as evs: # p.ex output of Examples/options/simple_
         gen_pdgid.clear()
         gen_status.clear()
         
+        cluster_cells.clear()
         cluster_eta.clear()
         cluster_phi.clear()
         cluster_pt.clear()

--- a/python/send.py
+++ b/python/send.py
@@ -397,8 +397,12 @@ if __name__=="__main__":
         # if signal events are used (simu/) or mixed pileup events (simuPU.../)
         if not args.mergePileup and not args.addPileupNoise and not args.addPileupToSignal and args.pileup and not (args.pileup == 0):
             inputID = os.path.join(yamldir, version, job_dir, 'simuPU'+str(args.pileup))
-            if args.rebase:
+            if args.rebase and not args.resegmentHCal:
                 inputID = os.path.join(yamldir, version, job_dir, 'simuPU'+str(args.pileup)+'/rebase/')
+            elif args.resegmentHCal and not args.rebase:
+                inputID = os.path.join(yamldir, version, job_dir, 'simuPU'+str(args.pileup)+'/resegmentedHCal/')
+            elif args.rebase and args.resegmentHCal:
+                inputID = os.path.join(yamldir, version, job_dir, 'simuPU'+str(args.pileup)+'/rebase/resegmentedHCal/')
         else:
             inputID = os.path.join(yamldir, version, job_dir, 'simu')
         outputID = os.path.join(yamldir, version, job_dir, job_type)

--- a/python/send.py
+++ b/python/send.py
@@ -87,6 +87,8 @@ def getJobInfo(argv):
         if '--addConeCut' in argv:
             job_type += "coneCut/"
             short_job_type += "_coneCut"
+            if '--noSignal' in argv:
+                job_type += "/noSignal/"
         return default_options,job_type,short_job_type,False
 
     elif '--recSlidingWindow' in argv:
@@ -137,7 +139,7 @@ def getJobInfo(argv):
             job_type += "resegmentedHCal/"
             short_job_type += "_resegmHCal"
         if '--calibrate' in argv:
-            job_type += "/calibrated/08_2018/"
+            job_type += "/calibrated/11_2018/"
             short_job_type += "_calib"
         return default_options,job_type,short_job_type,False
     
@@ -208,6 +210,7 @@ if __name__=="__main__":
     parser.add_argument("--tripletTracker", action="store_true", help="Use triplet tracker layout instead of baseline")
     parser.add_argument("--addConeCut", action='store_true', help="Add a cone-based cut for selection of cells/clusters.")
     parser.add_argument("--cone", type=float, required = '--addConeCut' in sys.argv, help="Cone size within cells/clusters are included in output.")     
+    parser.add_argument("--noSignal", action='store_true', help="In cone selection, select non-signal region (opposite eta of gen particle).")
     default_options,job_type,short_job_type,sim = getJobInfo(sys.argv)
     parser.add_argument('--jobOptions', type=str, default = default_options, help='Name of the job options run by FCCSW (default config/geantSim.py')
 
@@ -396,10 +399,12 @@ if __name__=="__main__":
         warning("Please note that '--preparePileup' is not supported for FCCSW v0.9.1. Make sure that you use suitable software version (recommended: '--local inits/reco.py')", True)
     if args.recPositions and not args.local == "inits/reco.py":
         warning("Please note that '--recPositions' is not supported for FCCSW v0.9.1. Make sure that you use suitable software version (recommended: '--local inits/reco.py')", True)
-    if args.recTopoClusters and not args.local == "inits/reco.py":
+    if args.recTopoClusters and not args.calibrate and not args.local == "inits/reco.py":
         warning("Please note that '--recTopoClusters' is not supported for FCCSW v0.9.1. Make sure that you use suitable software version (recommended: '--local inits/reco.py')", True)
     if args.recTopoClusters and args.numEvents != -1:
         warning("Please note that '--recTopoClusters' is not run on all events available in simu (recommended: '--n -1')", True)
+    if args.calibrate and not args.local == "inits/calibrateCluster.py":
+        warning("Please note that '--calibrate' is not supported for FCCSW v0.9.1. Make sure that you use suitable software version (recommended: '--local inits/calibrateCluster.py')", True)
 
     # first make sure the output path for root files exists
     outdir = os.path.join( output_path, version, job_dir, job_type)
@@ -618,8 +623,11 @@ if __name__=="__main__":
                 common_recPos_command += ' --resegmentedHCal '
             if args.addConeCut:
                 common_recPos_command += ' --cone %f'%(args.cone)
+                if args.noSignal:
+                    common_recPos_command += ' --noSignal '
             frun.write(common_recPos_command)
             frun.write('\n python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/cells_%s.root %s/%s\n'%(seed,outdir,outfile))
+            frun.write('rm $JOBDIR/cells_%s.root \n'%(seed))
         elif args.recTopoClusters or args.recSlidingWindow:
             if args.resegmentHCal:
                 frun.write('python %s/python/Convert.py $JOBDIR/%s $JOBDIR/clusters_%s.root --resegmentedHCal \n'%(current_dir,outfile,seed))

--- a/python/send.py
+++ b/python/send.py
@@ -96,8 +96,11 @@ def getJobInfo(argv):
 
     elif '--estimatePileup' in sys.argv:
         default_options = 'config/preparePileup.py'
-        job_type = "ana/fullBarrel/pileup_cluster"
+        job_type = "ana/fullBarrel/pileup/"
         short_job_type = "pileup"
+        if '--resegmentHCal' in argv:
+            job_type += "resegmentedHCal/"
+            short_job_type += "_resegmHCal"
         return default_options,job_type,short_job_type,False
 
     elif '--mergePileup' in sys.argv:
@@ -289,6 +292,9 @@ if __name__=="__main__":
         if args.rebase:
             short_job_type += "_rebase"
             job_type += "/rebase/"
+        if args.resegmentHCal:
+            short_job_type += "_resegmHCal"
+            job_type += "resegmentedHCal/"
         num_events = args.numEvents
     elif args.estimatePileup and args.pileup:
         short_job_type += "_PU"+str(args.pileup)
@@ -411,7 +417,10 @@ if __name__=="__main__":
     # merging pileup events will be done randomly from a given event pool
     if args.mergePileup or args.addPileupToSignal:
         all_inputs = ""
-        if args.addPileupToSignal: 
+        if args.addPileupToSignal:
+            path_to_input_withPU = 'physics/MinBias/'+b_field_str+'/etaFull/simuPU'+str(args.pileup)+'/'
+            if args.resegmentHCal:
+                path_to_input_withPU += 'resegmentedHCal/'
             inputPileupID = os.path.join(yamldir, version, 'physics/MinBias/'+b_field_str+'/etaFull/simuPU'+str(args.pileup)+'/')
             pileup_input_files = getInputFiles(inputPileupID)
         else: 

--- a/python/send.py
+++ b/python/send.py
@@ -76,11 +76,14 @@ def takeOnlyNonexistingFiles(files, output):
 def getJobInfo(argv):
     if '--recPositions' in argv:
         default_options = 'config/recPositions.py'
-        job_type = "ntup/positions"
+        job_type = "ntup/positions/"
         short_job_type = "recPos"
         if '--resegmentHCal' in argv:
-            job_type = "ntup/resegmentedHCal/positions"
+            job_type = "ntup/positions/resegmentedHCal/"
             short_job_type += "_resegmHCal"
+        if '--noise' in argv:
+            job_type += "electronicsNoise/"
+            short_job_type += "_addNoise"
         return default_options,job_type,short_job_type,False
 
     elif '--recSlidingWindow' in argv:
@@ -605,7 +608,7 @@ if __name__=="__main__":
             if args.resegmentHCal:
                 frun.write('python %s/python/Convert.py edm.root $JOBDIR/%s --resegmentedHCal \n'%(current_dir,outfile))
             else:
-                frun.write('python %s/python/Convert.py edm.root $JOBDIR/%s\n'%(current_dir,outfile))
+                frun.write('python %s/python/Convert.py edm.root $JOBDIR/%s \n'%(current_dir,outfile))
             frun.write('rm edm.root \n')
         elif args.recTopoClusters or args.recSlidingWindow:
             if args.resegmentHCal:


### PR DESCRIPTION
major changes in: 
- Convert.py: loop over edm collections to extract smeared vertex
- recTopoClusters.py: calibrate HCAL on EM scale, if not use benchmark method, allows use different HCAL segmentation
- recPositions.py: can add electronics noise on Calo cells, should only be used when a cone selection is chosen with --addConeCut (cone size given with e.g. --cone 0.4)
- overlayPileup.py: runs on MinBias to create PU scenarios and adds PU events on signal
- preparePileup.py: runs also on HCal cells, used to determine cell noise from PU events
- send.py: has all new options in (--benchmark: benchmark calibration on topo-clusters, parameters from cell optimisations; --calibrate: energy depended tops-cluster calibration; --rebase: correct cell energies for average PU contribution before overlaying with signal; --addConeCut: selects cells around a cone of the gen_particle, this can be used on cell or topo-clusters. on the top-clusters it selects the input cells for the clustering, cone radius given with --cone x; --resegmentHCal is propagated through all configs where it is needed.)

TODO: remove windowCut, not used.
